### PR TITLE
Sammy param datareduction

### DIFF
--- a/src/pleiades/sammy/parameters/data_reduction.py
+++ b/src/pleiades/sammy/parameters/data_reduction.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+"""Data class for card 08::data reduction parameters."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from pleiades.sammy.parameters.helper import VaryFlag, format_float, format_vary, safe_parse
+
+# Format definitions for fixed-width fields
+FORMAT_PARAMETER = {
+    "name": slice(0, 5),  # Parameter name (alphanumeric)
+    "flag": slice(6, 7),  # Vary flag (0=fixed, 1=varied, 3=PUP)
+    "value": slice(10, 20),  # Parameter value
+    "uncertainty": slice(20, 30),  # Absolute uncertainty
+    "derivative": slice(30, 40),  # Value for partial derivatives
+}
+
+CARD_8_HEADER = "DATA reduction parameters are next"
+
+
+class DataReductionParameter(BaseModel):
+    """Container for a single data reduction parameter entry.
+
+    Each parameter has:
+    - A name (5-char alphanumeric)
+    - A value
+    - A flag indicating whether it should be varied
+    - Optional uncertainty
+    - Optional derivative value
+    """
+
+    name: str = Field(max_length=5)
+    value: float
+    flag: VaryFlag = Field(default=VaryFlag.NO)
+    uncertainty: Optional[float] = None
+    derivative_value: Optional[float] = None
+
+    @model_validator(mode="after")
+    def validate_name(self) -> "DataReductionParameter":
+        """Validate name field is not empty and fits format."""
+        if not self.name or len(self.name) > 5:
+            raise ValueError("Name must be 1-5 characters")
+        return self
+
+    @classmethod
+    def from_line(cls, line: str) -> "DataReductionParameter":
+        """Parse parameter from a fixed-width format line.
+
+        Args:
+            line: Input line
+
+        Returns:
+            DataReductionParameter: Parsed parameter
+
+        Raises:
+            ValueError: If line is invalid or required data missing
+        """
+        if not line.strip():
+            raise ValueError("Empty line provided")
+
+        # Parse name (required)
+        name = line[FORMAT_PARAMETER["name"]].strip()
+        if not name:
+            raise ValueError("Parameter name is required")
+
+        # Parse value (required)
+        value = safe_parse(line[FORMAT_PARAMETER["value"]])
+        if value is None:
+            raise ValueError(f"Invalid or missing value for parameter {name}")
+
+        # Parse flag
+        flag_str = line[FORMAT_PARAMETER["flag"]].strip() or "0"
+        try:
+            flag = VaryFlag(int(flag_str))
+        except (ValueError, TypeError):
+            flag = VaryFlag.NO
+
+        # Parse optional fields
+        uncertainty = safe_parse(line[FORMAT_PARAMETER["uncertainty"]])
+        derivative = safe_parse(line[FORMAT_PARAMETER["derivative"]])
+
+        return cls(name=name, value=value, flag=flag, uncertainty=uncertainty, derivative_value=derivative)
+
+    def to_line(self) -> str:
+        """Convert the parameter to a fixed-width format line.
+
+        Returns:
+            str: Formatted line
+        """
+        parts = [
+            f"{self.name:<5}",
+            " ",
+            format_vary(self.flag),
+            "   ",  # 3 spaces padding
+            format_float(self.value, width=10),
+            format_float(self.uncertainty, width=10),
+            format_float(self.derivative_value, width=10),
+        ]
+        return "".join(parts)
+
+
+class DataReductionCard(BaseModel):
+    """Container for a complete data reduction parameter card set (Card Set 8).
+
+    This class handles:
+    - Header line
+    - Multiple parameter entries
+    - Trailing blank line
+    """
+
+    parameters: List[DataReductionParameter]
+
+    @classmethod
+    def is_header_line(cls, line: str) -> bool:
+        """Check if line is a valid header line."""
+        return line.strip().upper().startswith("DATA")
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "DataReductionCard":
+        """Parse a complete data reduction card set from lines.
+
+        Args:
+            lines: List of input lines including header
+
+        Returns:
+            DataReductionCard: Parsed card set
+
+        Raises:
+            ValueError: If no valid header found or invalid format
+        """
+        if not lines:
+            raise ValueError("No lines provided")
+
+        # Validate header
+        if not cls.is_header_line(lines[0]):
+            raise ValueError(f"Invalid header line: {lines[0]}")
+
+        # Parse parameters (skip header and trailing blank lines)
+        parameters = []
+        for line in lines[1:]:
+            if not line.strip():
+                continue
+            try:
+                param = DataReductionParameter.from_line(line)
+                parameters.append(param)
+            except ValueError as e:
+                raise ValueError(f"Error parsing parameter line: {e}")
+
+        if not parameters:
+            raise ValueError("No parameter lines found")
+
+        return cls(parameters=parameters)
+
+    def to_lines(self) -> List[str]:
+        """Convert the card set to a list of lines.
+
+        Returns:
+            List[str]: Lines including header and parameters
+        """
+        lines = [CARD_8_HEADER]
+        for param in self.parameters:
+            lines.append(param.to_line())
+        lines.append("")  # Trailing blank line
+        return lines
+
+
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(level=logging.DEBUG)
+
+    # Test single parameter parsing
+    logging.debug("**Testing single parameter parsing**")
+    param_line = "PARAM 1   1.234E+00 5.000E-02 1.234E+00"
+
+    for k, v in FORMAT_PARAMETER.items():
+        tmp = param_line[v]
+        print(f"{k}: {v} -- {tmp}")  # Debugging output
+
+    try:
+        param = DataReductionParameter.from_line(param_line)
+        logging.debug(f"Successfully parsed parameter: {param.name} = {param.value}")
+        logging.debug(f"Output line: '{param.to_line()}'")
+    except ValueError as e:
+        logging.error(f"Failed to parse parameter: {e}")
+
+    # Test complete card set
+    logging.debug("\n**Testing complete card set**")
+    card_lines = [
+        "DATA reduction parameters are next",
+        "PAR1   1   1.234E+00 5.000E-02 1.234E+00",
+        "PAR2   0   2.345E+00 1.000E-02",
+        "PAR3   3   3.456E+00",
+        "",
+    ]
+
+    try:
+        card = DataReductionCard.from_lines(card_lines)
+        logging.debug("Successfully parsed card set")
+        logging.debug("Output lines:")
+        for line in card.to_lines():
+            logging.debug(f"'{line}'")
+    except ValueError as e:
+        logging.error(f"Failed to parse card set: {e}")
+
+    # Test error handling
+    logging.debug("\n**Testing error handling**")
+
+    # Test invalid header
+    try:
+        bad_lines = ["WRONG header", "PAR1  1 1.234E+00", ""]
+        DataReductionCard.from_lines(bad_lines)
+    except ValueError as e:
+        logging.debug(f"Caught expected error for invalid header: {e}")
+
+    # Test invalid parameter line
+    try:
+        bad_param = "PAR1  X invalid_value"
+        DataReductionParameter.from_line(bad_param)
+    except ValueError as e:
+        logging.debug(f"Caught expected error for invalid parameter line: {e}")

--- a/tests/unit/pleiades/sammy/parameters/test_data_reduction.py
+++ b/tests/unit/pleiades/sammy/parameters/test_data_reduction.py
@@ -1,0 +1,117 @@
+import pytest
+
+from pleiades.sammy.parameters.data_reduction import DataReductionCard, DataReductionParameter
+from pleiades.sammy.parameters.helper import VaryFlag
+
+
+def test_parameter_parsing():
+    """Test parsing single parameter line."""
+    line = "PAR1  1   1.234E+00 5.000E-02 1.234E+00"
+    param = DataReductionParameter.from_line(line)
+
+    assert param.name == "PAR1"
+    assert param.flag == VaryFlag.YES
+    assert pytest.approx(param.value) == 1.234
+    assert pytest.approx(param.uncertainty) == 0.05
+    assert pytest.approx(param.derivative_value) == 1.234
+
+
+def test_parameter_optional_fields():
+    """Test parsing parameter with missing optional fields."""
+    line = "PAR1  1   1.234E+00"
+    param = DataReductionParameter.from_line(line)
+
+    assert param.name == "PAR1"
+    assert param.flag == VaryFlag.YES
+    assert pytest.approx(param.value) == 1.234
+    assert param.uncertainty is None
+    assert param.derivative_value is None
+
+
+def test_parameter_formatting():
+    """Test parameter line formatting."""
+    param = DataReductionParameter(name="PAR1", value=1.234, flag=VaryFlag.YES, uncertainty=0.05, derivative_value=1.234)
+    line = param.to_line()
+
+    # Parse back to verify format
+    parsed = DataReductionParameter.from_line(line)
+    assert parsed.name == param.name
+    assert parsed.flag == param.flag
+    assert pytest.approx(parsed.value) == param.value
+    assert pytest.approx(parsed.uncertainty) == param.uncertainty
+    assert pytest.approx(parsed.derivative_value) == param.derivative_value
+
+
+def test_card_parsing():
+    """Test parsing complete card set."""
+    lines = [
+        "DATA reduction parameters are next",
+        "PAR1  1   1.234E+00 5.000E-02 1.234E+00",
+        "PAR2  0   2.345E+00 1.000E-02",
+        "PAR3  3   3.456E+00",
+        "",
+    ]
+
+    card = DataReductionCard.from_lines(lines)
+    assert len(card.parameters) == 3
+
+    # Check first parameter
+    assert card.parameters[0].name == "PAR1"
+    assert card.parameters[0].flag == VaryFlag.YES
+    assert pytest.approx(card.parameters[0].value) == 1.234
+
+    # Check PUP parameter
+    assert card.parameters[2].name == "PAR3"
+    assert card.parameters[2].flag == VaryFlag.PUP
+    assert pytest.approx(card.parameters[2].value) == 3.456
+
+
+def test_card_formatting():
+    """Test card set formatting."""
+    params = [
+        DataReductionParameter(name="PAR1", value=1.234, flag=VaryFlag.YES, uncertainty=0.05, derivative_value=1.234),
+        DataReductionParameter(name="PAR2", value=2.345, flag=VaryFlag.NO, uncertainty=0.01),
+        DataReductionParameter(name="PAR3", value=3.456, flag=VaryFlag.PUP),
+    ]
+    card = DataReductionCard(parameters=params)
+    lines = card.to_lines()
+
+    # Parse back to verify format
+    parsed = DataReductionCard.from_lines(lines)
+    assert len(parsed.parameters) == len(card.parameters)
+    for orig, new in zip(card.parameters, parsed.parameters):
+        assert new.name == orig.name
+        assert new.flag == orig.flag
+        assert pytest.approx(new.value) == orig.value
+        if orig.uncertainty is not None:
+            assert pytest.approx(new.uncertainty) == orig.uncertainty
+        if orig.derivative_value is not None:
+            assert pytest.approx(new.derivative_value) == orig.derivative_value
+
+
+def test_invalid_parameter():
+    """Test error handling for invalid parameter lines."""
+    with pytest.raises(ValueError):
+        DataReductionParameter.from_line("")  # Empty line
+
+    with pytest.raises(ValueError):
+        DataReductionParameter.from_line("PAR1  X invalid")  # Invalid value
+
+    with pytest.raises(ValueError):
+        DataReductionParameter(name="TOOLONG", value=1.0)  # Name too long
+
+
+def test_invalid_card():
+    """Test error handling for invalid card sets."""
+    with pytest.raises(ValueError):
+        DataReductionCard.from_lines([])  # Empty lines
+
+    with pytest.raises(ValueError):
+        DataReductionCard.from_lines(["WRONG HEADER"])  # Invalid header
+
+    with pytest.raises(ValueError):
+        DataReductionCard.from_lines(["DATA reduction parameters are next", ""])  # No parameters
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
Add parser for data reduction card.

> EWM item: [Story 8967](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8967)
---

This pull request introduces a new data model for handling data reduction parameters in the `pleiades.sammy.parameters` module. The changes include the creation of data classes for parsing and formatting these parameters, as well as unit tests to ensure the functionality is correct.

### New Data Model for Data Reduction Parameters:

* [`src/pleiades/sammy/parameters/data_reduction.py`](diffhunk://#diff-3d39421e17977bb33984f31c7b722ec8fb33598825b5035e82712aad7ed9fa3dR1-R222): Added new data classes `DataReductionParameter` and `DataReductionCard` for parsing, validating, and formatting data reduction parameters from fixed-width formatted lines.

### Unit Tests:

* [`tests/unit/pleiades/sammy/parameters/test_data_reduction.py`](diffhunk://#diff-93ca2af02cdf5ecc375736907da6140e3827d22e7315d65833b7185b67804219R1-R117): Added unit tests to verify the parsing, formatting, and error handling of the new data reduction parameter classes.