### PR TITLE
Add ORRSE card for SAMMY parameter class

### DIFF
--- a/src/pleiades/sammy/parameters/__init__.py
+++ b/src/pleiades/sammy/parameters/__init__.py
@@ -2,6 +2,7 @@ from pleiades.sammy.parameters.broadening import BroadeningParameterCard  # noqa
 from pleiades.sammy.parameters.data_reduction import DataReductionCard  # noqa: F401
 from pleiades.sammy.parameters.external_r import ExternalREntry  # noqa: F401
 from pleiades.sammy.parameters.normalization import NormalizationBackgroundCard  # noqa: F401
+from pleiades.sammy.parameters.orres import ORRESCard  # noqa: F401
 from pleiades.sammy.parameters.radius import RadiusCard  # noqa: F401
 from pleiades.sammy.parameters.resonance import ResonanceEntry  # noqa: F401
 from pleiades.sammy.parameters.unused_var import UnusedCorrelatedCard  # noqa: F401

--- a/src/pleiades/sammy/parameters/__init__.py
+++ b/src/pleiades/sammy/parameters/__init__.py
@@ -1,5 +1,7 @@
 from pleiades.sammy.parameters.broadening import BroadeningParameterCard  # noqa: F401
+from pleiades.sammy.parameters.data_reduction import DataReductionCard  # noqa: F401
 from pleiades.sammy.parameters.external_r import ExternalREntry  # noqa: F401
 from pleiades.sammy.parameters.normalization import NormalizationBackgroundCard  # noqa: F401
+from pleiades.sammy.parameters.radius import RadiusCard  # noqa: F401
 from pleiades.sammy.parameters.resonance import ResonanceEntry  # noqa: F401
 from pleiades.sammy.parameters.unused_var import UnusedCorrelatedCard  # noqa: F401

--- a/src/pleiades/sammy/parameters/helper.py
+++ b/src/pleiades/sammy/parameters/helper.py
@@ -48,12 +48,20 @@ def format_float(value: Optional[float], width: int = 11) -> str:
     format_str = f"{{:.{max_decimals}E}}"
     formatted = format_str.format(value)
 
-    # Ensure the string fits the width
-    if len(formatted) > width:
+    # If it fits, return the formatted scientific notation
+    if len(formatted) <= width:
+        return f"{formatted:<{width}}"
+
+    # Fall back to standard float format
+    max_decimals_f = max(0, width - len(f"{int(value):d}") - 2)  # Leave room for "-" and "."
+    format_str_float = f"{{:.{max_decimals_f}f}}"
+    formatted_float = format_str_float.format(value)
+
+    # Ensure the fallback fits
+    if len(formatted_float) > width:
         raise ValueError(f"Cannot format value {value} to fit in {width} characters.")
 
-    # Align to the left if required
-    return f"{formatted:<{width}}"
+    return f"{formatted_float:<{width}}"
 
 
 def format_vary(value: VaryFlag) -> str:

--- a/src/pleiades/sammy/parameters/orres.py
+++ b/src/pleiades/sammy/parameters/orres.py
@@ -608,9 +608,9 @@ class ChannelParameters(BaseModel):
             " ",
             format_vary(self.flag_chann),
             "   ",
-            format_float(self.ecrnch, width=9),
-            format_float(self.chann, width=9),
-            format_float(self.d_chann, width=9) if self.d_chann else "",
+            format_float(self.ecrnch, width=10),
+            format_float(self.chann, width=10),
+            format_float(self.d_chann, width=10) if self.d_chann else "",
         ]
         return ["".join(parts)]
 

--- a/src/pleiades/sammy/parameters/orres.py
+++ b/src/pleiades/sammy/parameters/orres.py
@@ -471,15 +471,18 @@ class LithiumParameters(BaseModel):
             format_vary(self.flag_d),
             format_vary(self.flag_f),
             format_vary(self.flag_g),
-            format_float(self.d, width=9),
-            format_float(self.f, width=9),
-            format_float(self.g, width=9),
+            " ",
+            format_float(self.d, width=10),
+            format_float(self.f, width=10),
+            format_float(self.g, width=10),
         ]
         lines.append("".join(main_parts))
 
         # Add uncertainties line if any present
         if any(getattr(self, f"d_{param}") is not None for param in ["d", "f", "g"]):
-            unc_parts = [format_float(self.d_d, width=9), format_float(self.d_f, width=9), format_float(self.d_g, width=9)]
+            unc_parts = [format_float(self.d_d, width=10), format_float(self.d_f, width=10), format_float(self.d_g, width=9)]
+            # pad the first 10 characters
+            unc_parts = [" " * 10] + unc_parts
             lines.append("".join(unc_parts))
 
         return lines

--- a/src/pleiades/sammy/parameters/orres.py
+++ b/src/pleiades/sammy/parameters/orres.py
@@ -1,0 +1,778 @@
+#!/usr/bin/env python
+"""Oak Ridge Resolution Function parameters (Card Set 9)."""
+
+from enum import Enum
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, Field, model_validator
+
+from pleiades.sammy.parameters.helper import VaryFlag, format_float, format_vary, safe_parse
+
+# Constants for header identifiers
+CARD_9_HEADER = "ORRES"
+
+
+class ModeratorType(Enum):
+    """Type of moderator used"""
+
+    WATER = "WATER"
+    TANTALUM = "TANTA"
+
+
+class DetectorType(Enum):
+    """Type of detector used"""
+
+    LITHIUM = "LITHI"
+    NE110 = "NE110"
+
+
+# Format definitions for fixed-width fields
+FORMAT_BURST = {
+    "burst": slice(10, 20),  # Burst width value
+    "flag_burst": slice(6, 7),  # Flag to vary burst
+    "d_burst": slice(20, 30),  # Uncertainty on burst
+}
+
+FORMAT_WATER = {
+    "flag_watr0": slice(6, 7),  # Flag for WATR0
+    "flag_watr1": slice(7, 8),  # Flag for WATR1
+    "flag_watr2": slice(8, 9),  # Flag for WATR2
+    "dof": slice(9, 10),  # Degrees of freedom
+    "watr0": slice(10, 20),  # Constant term
+    "watr1": slice(20, 30),  # Linear term
+    "watr2": slice(30, 40),  # Quadratic term
+    "d_watr0": slice(10, 20),  # Uncertainty on WATR0
+    "d_watr1": slice(20, 30),  # Uncertainty on WATR1
+    "d_watr2": slice(30, 40),  # Uncertainty on WATR2
+}
+
+FORMAT_TANTA = {
+    # First line
+    "flag_tanta": slice(6, 7),  # Flag for TANTA
+    "tanta": slice(10, 20),  # Main parameter
+    "d_tanta": slice(20, 30),  # Uncertainty on TANTA
+    # Second line
+    "flag_x1": slice(6, 7),  # Flag for X1
+    "flag_x2": slice(7, 8),  # Flag for X2
+    "flag_x3": slice(8, 9),  # Flag for X3
+    "flag_x0": slice(9, 10),  # Flag for X0
+    "x1": slice(10, 20),  # x'1 parameter
+    "x2": slice(20, 30),  # x'2 parameter
+    "x3": slice(30, 40),  # x'3 parameter
+    "x0": slice(40, 50),  # x'0 parameter
+    # Third line - uncertainties
+    "d_x1": slice(10, 20),  # Uncertainty on X1
+    "d_x2": slice(20, 30),  # Uncertainty on X2
+    "d_x3": slice(30, 40),  # Uncertainty on X3
+    "d_x0": slice(40, 50),  # Uncertainty on X0
+    # Fourth line - beta/alpha
+    "flag_beta": slice(6, 7),  # Flag for beta
+    "flag_alpha": slice(7, 8),  # Flag for alpha
+    "beta": slice(10, 20),  # Beta parameter
+    "alpha": slice(20, 30),  # Alpha parameter
+    # Fifth line - uncertainties
+    "d_beta": slice(10, 20),  # Uncertainty on beta
+    "d_alpha": slice(20, 30),  # Uncertainty on alpha
+}
+
+FORMAT_LITHI = {
+    "flag_d": slice(6, 7),  # Flag for d
+    "flag_f": slice(7, 8),  # Flag for f
+    "flag_g": slice(8, 9),  # Flag for g
+    "d": slice(10, 20),  # d parameter
+    "f": slice(20, 30),  # f parameter
+    "g": slice(30, 40),  # g parameter
+    "d_d": slice(10, 20),  # Uncertainty on d
+    "d_f": slice(20, 30),  # Uncertainty on f
+    "d_g": slice(30, 40),  # Uncertainty on g
+}
+
+FORMAT_NE110 = {
+    "flag_delta": slice(6, 7),  # Flag for delta
+    "num_points": slice(7, 10),  # Number of E/sigma points
+    "delta": slice(10, 20),  # Delta parameter
+    "d_delta": slice(20, 30),  # Uncertainty on delta
+    "density": slice(30, 40),  # Density parameter
+    # Format for E/sigma points
+    "energy": slice(10, 20),  # Energy value
+    "sigma": slice(20, 30),  # Cross section value
+}
+
+FORMAT_CHANNEL = {
+    "flag_chann": slice(6, 7),  # Flag for channel width
+    "ecrnch": slice(10, 20),  # Maximum energy
+    "chann": slice(20, 30),  # Channel width
+    "d_chann": slice(30, 40),  # Uncertainty on width
+}
+
+
+# Individual parameter models for each section
+class BurstParameters(BaseModel):
+    """Burst width parameters.
+
+    This models the BURST section of ORRES card that specifies:
+    - Burst width in nanoseconds
+    - Flag indicating whether to vary/PUP the parameter
+    - Optional uncertainty on the burst width
+    """
+
+    burst: float = Field(description="Full width at half max of burst (ns)")
+    flag_burst: VaryFlag = Field(default=VaryFlag.NO, description="Flag to vary burst width")
+    d_burst: Optional[float] = Field(None, description="Uncertainty on burst width (ns)")
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "BurstParameters":
+        """Parse burst parameters from input lines.
+
+        Args:
+            lines: List of lines containing burst parameters
+
+        Returns:
+            BurstParameters object
+
+        Raises:
+            ValueError: If required data missing or invalid format
+        """
+        if not lines or not lines[0].strip():
+            raise ValueError("No valid parameter line provided")
+
+        # Parse main line
+        line = f"{lines[0]:<30}"  # Pad to minimum width
+
+        params = {}
+
+        # Parse burst width
+        burst = safe_parse(line[FORMAT_BURST["burst"]])
+        if burst is not None:
+            params["burst"] = burst
+
+        # Parse vary flag
+        flag_val = line[FORMAT_BURST["flag_burst"]].strip() or "0"
+        try:
+            params["flag_burst"] = VaryFlag(int(flag_val))
+        except (ValueError, TypeError):
+            params["flag_burst"] = VaryFlag.NO
+
+        # Parse uncertainty if present
+        d_burst = safe_parse(line[FORMAT_BURST["d_burst"]])
+        if d_burst is not None:
+            params["d_burst"] = d_burst
+
+        return cls(**params)
+
+    def to_lines(self) -> List[str]:
+        """Convert parameters to fixed-width format lines.
+
+        Returns:
+            List containing the formatted parameter line
+        """
+        # Format main parameters using helper functions
+        parts = [
+            "BURST".ljust(5),  # Section identifier
+            " ",  # Spacing
+            format_vary(self.flag_burst),
+            "   ",  # Additional spacing
+            format_float(self.burst, width=10),
+            format_float(self.d_burst, width=10) if self.d_burst is not None else "",
+        ]
+
+        return ["".join(parts)]
+
+
+class WaterParameters(BaseModel):
+    """Water moderator parameters for the ORRES card.
+
+    Contains parameters for mean free path coefficients:
+    - Constant term (WATR0)
+    - Linear term (WATR1)
+    - Quadratic term (WATR2)
+    - Degrees of freedom for chi-squared distribution
+    - Vary flags and uncertainties for each parameter
+    """
+
+    watr0: float = Field(default=3.614, description="Constant term in mean free path expression (mm)")
+    watr1: float = Field(default=-0.089, description="Linear term in mean free path expression (mm)")
+    watr2: float = Field(default=0.037, description="Quadratic term in mean free path expression (mm)")
+    dof: int = Field(default=4, description="Degrees of freedom for chi-squared distribution", ge=1)
+
+    flag_watr0: VaryFlag = Field(default=VaryFlag.NO)
+    flag_watr1: VaryFlag = Field(default=VaryFlag.NO)
+    flag_watr2: VaryFlag = Field(default=VaryFlag.NO)
+
+    d_watr0: Optional[float] = Field(None, description="Uncertainty on WATR0")
+    d_watr1: Optional[float] = Field(None, description="Uncertainty on WATR1")
+    d_watr2: Optional[float] = Field(None, description="Uncertainty on WATR2")
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "WaterParameters":
+        """Parse water moderator parameters from input lines."""
+        if not lines or not lines[0].strip():
+            raise ValueError("No valid parameter line provided")
+
+        line = f"{lines[0]:<40}"  # Main parameters line
+        params = {}
+
+        # Parse main parameters
+        for param in ["watr0", "watr1", "watr2"]:
+            value = safe_parse(line[FORMAT_WATER[param]])
+            if value is not None:
+                params[param] = value
+
+        # Parse flags
+        for flag in ["flag_watr0", "flag_watr1", "flag_watr2"]:
+            value = line[FORMAT_WATER[flag]].strip() or "0"
+            try:
+                params[flag] = VaryFlag(int(value))
+            except (ValueError, TypeError):
+                params[flag] = VaryFlag.NO
+
+        # Parse degrees of freedom
+        dof = safe_parse(line[FORMAT_WATER["dof"]], as_int=True)
+        if dof is not None and dof > 0:
+            params["dof"] = dof
+
+        # Parse uncertainties if present
+        if len(lines) > 1 and lines[1].strip():
+            unc_line = f"{lines[1]:<40}"
+            for param in ["d_watr0", "d_watr1", "d_watr2"]:
+                value = safe_parse(unc_line[FORMAT_WATER[param]])
+                if value is not None:
+                    params[param] = value
+
+        return cls(**params)
+
+    def to_lines(self) -> List[str]:
+        """Convert parameters to fixed-width format lines."""
+        lines = []
+
+        # Main parameters line
+        main_parts = [
+            "WATER".ljust(5),
+            " ",
+            format_vary(self.flag_watr0),
+            format_vary(self.flag_watr1),
+            format_vary(self.flag_watr2),
+            str(self.dof),
+            format_float(self.watr0, width=9),
+            format_float(self.watr1, width=9),
+            format_float(self.watr2, width=9),
+        ]
+        lines.append("".join(main_parts))
+
+        # Add uncertainties line if any uncertainties present
+        if any(getattr(self, f"d_{param}") is not None for param in ["watr0", "watr1", "watr2"]):
+            unc_parts = [format_float(getattr(self, f"d_{param}", 0.0), width=10) for param in ["watr0", "watr1", "watr2"]]
+            lines.append("".join(unc_parts))
+
+        return lines
+
+
+class TantalumParameters(BaseModel):
+    """Tantalum target parameters for ORRES card."""
+
+    # Main parameter
+    tanta: float = Field(description="η' parameter (mm⁻¹)")
+    flag_tanta: VaryFlag = Field(default=VaryFlag.NO)
+    d_tanta: Optional[float] = Field(None, description="Uncertainty on TANTA")
+
+    # Position parameters
+    x0: float = Field(description="x'₀ parameter (mm)")
+    x1: float = Field(description="x'₁ parameter (mm)")
+    x2: float = Field(description="x'₂ parameter (mm)")
+    x3: float = Field(description="x'₃ parameter (mm)")
+
+    flag_x0: VaryFlag = Field(default=VaryFlag.NO)
+    flag_x1: VaryFlag = Field(default=VaryFlag.NO)
+    flag_x2: VaryFlag = Field(default=VaryFlag.NO)
+    flag_x3: VaryFlag = Field(default=VaryFlag.NO)
+
+    d_x0: Optional[float] = Field(None)
+    d_x1: Optional[float] = Field(None)
+    d_x2: Optional[float] = Field(None)
+    d_x3: Optional[float] = Field(None)
+
+    # Shape parameters
+    beta: float = Field(description="β' parameter (mm⁻¹)")
+    alpha: float = Field(description="α' parameter (dimensionless)")
+
+    flag_beta: VaryFlag = Field(default=VaryFlag.NO)
+    flag_alpha: VaryFlag = Field(default=VaryFlag.NO)
+
+    d_beta: Optional[float] = Field(None)
+    d_alpha: Optional[float] = Field(None)
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "TantalumParameters":
+        """Parse parameters from input lines."""
+        if len(lines) < 5:
+            raise ValueError("Insufficient lines for Tantalum parameters")
+
+        params = {}
+
+        # First line - main parameter
+        line1 = f"{lines[0]:<30}"
+        params["tanta"] = safe_parse(line1[FORMAT_TANTA["tanta"]])
+        params["flag_tanta"] = VaryFlag(int(line1[FORMAT_TANTA["flag_tanta"]].strip() or "0"))
+        if d_tanta := safe_parse(line1[FORMAT_TANTA["d_tanta"]]):
+            params["d_tanta"] = d_tanta
+
+        # Second line - position parameters
+        line2 = f"{lines[1]:<50}"
+        for x in ["x0", "x1", "x2", "x3"]:
+            params[x] = safe_parse(line2[FORMAT_TANTA[x]])
+            flag_val = line2[FORMAT_TANTA[f"flag_{x}"]].strip() or "0"
+            params[f"flag_{x}"] = VaryFlag(int(flag_val))
+
+        # Third line - position uncertainties
+        line3 = f"{lines[2]:<50}"
+        for x in ["x0", "x1", "x2", "x3"]:
+            if d_x := safe_parse(line3[FORMAT_TANTA[f"d_{x}"]]):
+                params[f"d_{x}"] = d_x
+
+        # Fourth line - shape parameters
+        line4 = f"{lines[3]:<30}"
+        params["beta"] = safe_parse(line4[FORMAT_TANTA["beta"]])
+        params["alpha"] = safe_parse(line4[FORMAT_TANTA["alpha"]])
+        params["flag_beta"] = VaryFlag(int(line4[FORMAT_TANTA["flag_beta"]].strip() or "0"))
+        params["flag_alpha"] = VaryFlag(int(line4[FORMAT_TANTA["flag_alpha"]].strip() or "0"))
+
+        # Fifth line - shape uncertainties
+        line5 = f"{lines[4]:<30}"
+        if d_beta := safe_parse(line5[FORMAT_TANTA["d_beta"]]):
+            params["d_beta"] = d_beta
+        if d_alpha := safe_parse(line5[FORMAT_TANTA["d_alpha"]]):
+            params["d_alpha"] = d_alpha
+
+        return cls(**params)
+
+    def to_lines(self) -> List[str]:
+        """Convert parameters to fixed-width format lines."""
+        lines = []
+
+        # Main parameter line
+        line1 = [
+            "TANTA".ljust(5),
+            " ",
+            format_vary(self.flag_tanta),
+            "   ",
+            format_float(self.tanta, width=9),
+            format_float(self.d_tanta, width=9) if self.d_tanta else "",
+        ]
+        lines.append("".join(line1))
+
+        # Position parameters
+        line2 = [
+            " " * 6,
+            format_vary(self.flag_x1),
+            format_vary(self.flag_x2),
+            format_vary(self.flag_x3),
+            format_vary(self.flag_x0),
+            format_float(self.x1, width=9),
+            format_float(self.x2, width=9),
+            format_float(self.x3, width=9),
+            format_float(self.x0, width=9),
+        ]
+        lines.append("".join(line2))
+
+        # Position uncertainties
+        line3 = [
+            " " * 10,
+            format_float(self.d_x1, width=9),
+            format_float(self.d_x2, width=9),
+            format_float(self.d_x3, width=9),
+            format_float(self.d_x0, width=9),
+        ]
+        lines.append("".join(line3))
+
+        # Shape parameters
+        line4 = [
+            " " * 6,
+            format_vary(self.flag_beta),
+            format_vary(self.flag_alpha),
+            "   ",
+            format_float(self.beta, width=9),
+            format_float(self.alpha, width=9),
+        ]
+        lines.append("".join(line4))
+
+        # Shape uncertainties
+        line5 = [" " * 10, format_float(self.d_beta, width=9), format_float(self.d_alpha, width=9)]
+        lines.append("".join(line5))
+
+        return lines
+
+
+class LithiumParameters(BaseModel):
+    """Lithium glass detector parameters."""
+
+    d: float = Field(description="d parameter (nsec)")
+    f: float = Field(description="f parameter (nsec⁻¹)")
+    g: float = Field(description="g parameter (dimensionless)")
+
+    flag_d: VaryFlag = Field(default=VaryFlag.NO)
+    flag_f: VaryFlag = Field(default=VaryFlag.NO)
+    flag_g: VaryFlag = Field(default=VaryFlag.NO)
+
+    d_d: Optional[float] = Field(None, description="Uncertainty on d")
+    d_f: Optional[float] = Field(None, description="Uncertainty on f")
+    d_g: Optional[float] = Field(None, description="Uncertainty on g")
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "LithiumParameters":
+        """Parse lithium detector parameters from input lines."""
+        if not lines or not lines[0].strip():
+            raise ValueError("No valid parameter line provided")
+
+        # Parse main line
+        line = f"{lines[0]:<40}"
+        params = {}
+
+        # Parse main parameters
+        for param in ["d", "f", "g"]:
+            value = safe_parse(line[FORMAT_LITHI[param]])
+            if value is not None:
+                params[param] = value
+
+        # Parse flags
+        for flag in ["flag_d", "flag_f", "flag_g"]:
+            value = line[FORMAT_LITHI[flag]].strip() or "0"
+            try:
+                params[flag] = VaryFlag(int(value))
+            except (ValueError, TypeError):
+                params[flag] = VaryFlag.NO
+
+        # Parse uncertainties if present
+        if len(lines) > 1 and lines[1].strip():
+            unc_line = f"{lines[1]:<40}"
+            for param in ["d_d", "d_f", "d_g"]:
+                value = safe_parse(unc_line[FORMAT_LITHI[param]])
+                if value is not None:
+                    params[param] = value
+
+        return cls(**params)
+
+    def to_lines(self) -> List[str]:
+        """Convert parameters to fixed-width format lines."""
+        lines = []
+
+        # Main parameters line
+        main_parts = [
+            "LITHI".ljust(5),
+            " ",
+            format_vary(self.flag_d),
+            format_vary(self.flag_f),
+            format_vary(self.flag_g),
+            format_float(self.d, width=9),
+            format_float(self.f, width=9),
+            format_float(self.g, width=9),
+        ]
+        lines.append("".join(main_parts))
+
+        # Add uncertainties line if any present
+        if any(getattr(self, f"d_{param}") is not None for param in ["d", "f", "g"]):
+            unc_parts = [format_float(self.d_d, width=9), format_float(self.d_f, width=9), format_float(self.d_g, width=9)]
+            lines.append("".join(unc_parts))
+
+        return lines
+
+
+class CrossSectionPoint(BaseModel):
+    """Single energy/cross-section point for NE110 detector."""
+
+    energy: float = Field(description="Maximum energy (eV)")
+    sigma: float = Field(description="Total cross section (barns)")
+
+
+class NE110Parameters(BaseModel):
+    """NE110 detector parameters."""
+
+    delta: float = Field(description="δ parameter (mm)")
+    flag_delta: VaryFlag = Field(default=VaryFlag.NO)
+    d_delta: Optional[float] = Field(None, description="Uncertainty on δ")
+    density: float = Field(default=0.0047, description="Number of molecules per mm.b")
+    cross_sections: Optional[List[CrossSectionPoint]] = Field(None)
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "NE110Parameters":
+        """Parse NE110 detector parameters from input lines."""
+        if not lines or not lines[0].strip():
+            raise ValueError("No valid parameter line provided")
+
+        line = f"{lines[0]:<40}"
+        params = {}
+
+        # Parse main parameters
+        params["delta"] = safe_parse(line[FORMAT_NE110["delta"]])
+        params["flag_delta"] = VaryFlag(int(line[FORMAT_NE110["flag_delta"]].strip() or "0"))
+
+        if d_delta := safe_parse(line[FORMAT_NE110["d_delta"]]):
+            params["d_delta"] = d_delta
+
+        if density := safe_parse(line[FORMAT_NE110["density"]]):
+            params["density"] = density
+
+        # Parse number of cross section points
+        num_points = safe_parse(line[FORMAT_NE110["num_points"]], as_int=True)
+
+        # Parse cross section data if present
+        if num_points and num_points > 0 and len(lines) > 1:
+            cross_sections = []
+            for line in lines[1 : num_points + 1]:
+                line = f"{line:<30}"
+                energy = safe_parse(line[FORMAT_NE110["energy"]])
+                sigma = safe_parse(line[FORMAT_NE110["sigma"]])
+                if energy is not None and sigma is not None:
+                    cross_sections.append(CrossSectionPoint(energy=energy, sigma=sigma))
+            if cross_sections:
+                params["cross_sections"] = cross_sections
+
+        return cls(**params)
+
+    def to_lines(self) -> List[str]:
+        """Convert parameters to fixed-width format lines."""
+        lines = []
+
+        # Main parameters
+        main_parts = [
+            "NE110".ljust(5),
+            " ",
+            format_vary(self.flag_delta),
+            str(len(self.cross_sections or [])).rjust(3),
+            format_float(self.delta, width=9),
+            format_float(self.d_delta, width=9),
+            format_float(self.density, width=9),
+        ]
+        lines.append("".join(main_parts))
+
+        # Cross section points
+        if self.cross_sections:
+            for point in self.cross_sections:
+                lines.append("".join([" " * 10, format_float(point.energy, width=9), format_float(point.sigma, width=9)]))
+
+        return lines
+
+
+class ChannelParameters(BaseModel):
+    """Channel width parameters."""
+
+    ecrnch: float = Field(description="Maximum energy for this channel width (eV)")
+    chann: float = Field(description="Channel width (ns)")
+    d_chann: Optional[float] = Field(None, description="Uncertainty on channel width")
+    flag_chann: VaryFlag = Field(default=VaryFlag.NO)
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> List["ChannelParameters"]:
+        """Parse multiple channel parameter entries.
+
+        Returns list since multiple channel definitions can exist."""
+        if not lines:
+            raise ValueError("No channel parameter lines provided")
+
+        channels = []
+        for line in lines:
+            if not line.strip():
+                continue
+
+            line = f"{line:<40}"
+            params = {}
+
+            params["ecrnch"] = safe_parse(line[FORMAT_CHANNEL["ecrnch"]])
+            params["chann"] = safe_parse(line[FORMAT_CHANNEL["chann"]])
+
+            if d_chann := safe_parse(line[FORMAT_CHANNEL["d_chann"]]):
+                params["d_chann"] = d_chann
+
+            flag_val = line[FORMAT_CHANNEL["flag_chann"]].strip() or "0"
+            params["flag_chann"] = VaryFlag(int(flag_val))
+
+            channels.append(cls(**params))
+
+        return channels
+
+    def to_lines(self) -> List[str]:
+        """Convert single channel parameter to fixed-width format."""
+        parts = [
+            "CHANN".ljust(5),
+            " ",
+            format_vary(self.flag_chann),
+            "   ",
+            format_float(self.ecrnch, width=9),
+            format_float(self.chann, width=9),
+            format_float(self.d_chann, width=9) if self.d_chann else "",
+        ]
+        return ["".join(parts)]
+
+
+class ORRESParameters(BaseModel):
+    """Main container for ORRES parameters with validation logic."""
+
+    burst: Optional[BurstParameters] = None
+    moderator: Optional[Union[WaterParameters, TantalumParameters]] = None
+    detector: Optional[Union[LithiumParameters, NE110Parameters]] = None
+    channels: Optional[List[ChannelParameters]] = None
+
+    @model_validator(mode="after")
+    def validate_components(self) -> "ORRESParameters":
+        """Validate mutual exclusivity and dependencies between components."""
+
+        # Check 1: Moderator type exclusivity
+        if isinstance(self.moderator, WaterParameters) and isinstance(self.moderator, TantalumParameters):
+            raise ValueError("Cannot have both Water and Tantalum moderators")
+
+        # Check 2: Detector type exclusivity
+        if isinstance(self.detector, LithiumParameters) and isinstance(self.detector, NE110Parameters):
+            raise ValueError("Cannot have both Lithium and NE110 detectors")
+
+        # Check 3: Channel parameters order
+        if self.channels and len(self.channels) > 1:
+            prev_energy = float("-inf")
+            for channel in self.channels:
+                if channel.ecrnch <= prev_energy:
+                    raise ValueError("Channel energies must be in increasing order")
+                prev_energy = channel.ecrnch
+
+        # Check 4: NE110 cross section data consistency
+        if isinstance(self.detector, NE110Parameters) and self.detector.cross_sections:
+            prev_energy = float("-inf")
+            for point in self.detector.cross_sections:
+                if point.energy <= prev_energy:
+                    raise ValueError("NE110 cross section energies must be in increasing order")
+                prev_energy = point.energy
+
+        return self
+
+    @classmethod
+    def parse_orres_parameters(cls, lines: List[str]) -> "ORRESParameters":
+        """Parse ORRES parameters from input lines."""
+        if not lines:
+            raise ValueError("No lines provided")
+
+        params = {}
+        current_section = None
+        section_lines = []
+
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+
+            # Detect section starts
+            if line.startswith("BURST"):
+                if section_lines:
+                    cls._process_section(current_section, section_lines, params)
+                current_section = "burst"
+                section_lines = [line]
+
+            elif line.startswith("WATER"):
+                if section_lines:
+                    cls._process_section(current_section, section_lines, params)
+                current_section = "water"
+                section_lines = [line]
+
+            elif line.startswith("TANTA"):
+                if section_lines:
+                    cls._process_section(current_section, section_lines, params)
+                current_section = "tanta"
+                section_lines = [line]
+
+            elif line.startswith("LITHI"):
+                if section_lines:
+                    cls._process_section(current_section, section_lines, params)
+                current_section = "lithi"
+                section_lines = [line]
+
+            elif line.startswith("NE110"):
+                if section_lines:
+                    cls._process_section(current_section, section_lines, params)
+                current_section = "ne110"
+                section_lines = [line]
+
+            elif line.startswith("CHANN"):
+                if section_lines:
+                    cls._process_section(current_section, section_lines, params)
+                current_section = "channel"
+                section_lines = [line]
+
+            else:
+                section_lines.append(line)
+
+        # Process final section
+        if section_lines:
+            cls._process_section(current_section, section_lines, params)
+
+        return cls(**params)
+
+    @staticmethod
+    def _process_section(section: str, lines: List[str], params: dict):
+        """Process lines for a given section."""
+        if section == "burst":
+            params["burst"] = BurstParameters.from_lines(lines)
+
+        elif section == "water":
+            params["moderator"] = WaterParameters.from_lines(lines)
+
+        elif section == "tanta":
+            params["moderator"] = TantalumParameters.from_lines(lines)
+
+        elif section == "lithi":
+            params["detector"] = LithiumParameters.from_lines(lines)
+
+        elif section == "ne110":
+            params["detector"] = NE110Parameters.from_lines(lines)
+
+        elif section == "channel":
+            params["channels"] = ChannelParameters.from_lines(lines)
+
+    def to_lines(self) -> List[str]:
+        """Convert all parameters to lines."""
+        lines = []
+
+        if self.burst:
+            lines.extend(self.burst.to_lines())
+
+        if isinstance(self.moderator, WaterParameters):
+            lines.extend(self.moderator.to_lines())
+        elif isinstance(self.moderator, TantalumParameters):
+            lines.extend(self.moderator.to_lines())
+
+        if isinstance(self.detector, LithiumParameters):
+            lines.extend(self.detector.to_lines())
+        elif isinstance(self.detector, NE110Parameters):
+            lines.extend(self.detector.to_lines())
+
+        if self.channels:
+            for channel in self.channels:
+                lines.extend(channel.to_lines())
+
+        return lines
+
+
+class ORRESCard(BaseModel):
+    """Container for complete ORRES card."""
+
+    parameters: ORRESParameters
+
+    @classmethod
+    def is_header_line(cls, line: str) -> bool:
+        return line.strip().upper().startswith("ORRES")
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "ORRESCard":
+        if not lines:
+            raise ValueError("No lines provided")
+
+        if not cls.is_header_line(lines[0]):
+            raise ValueError(f"Invalid header line: {lines[0]}")
+
+        parameters = ORRESParameters.parse_orres_parameters(lines[1:])
+        return cls(parameters=parameters)
+
+    def to_lines(self) -> List[str]:
+        lines = ["ORRES"]
+        lines.extend(self.parameters.to_lines())
+        lines.append("")  # Trailing blank line
+        return lines
+
+
+if __name__ == "__main__":
+    print("TODO: usage example for ORRES card handling")

--- a/src/pleiades/sammy/parameters/orres.py
+++ b/src/pleiades/sammy/parameters/orres.py
@@ -550,16 +550,16 @@ class NE110Parameters(BaseModel):
             " ",
             format_vary(self.flag_delta),
             str(len(self.cross_sections or [])).rjust(3),
-            format_float(self.delta, width=9),
-            format_float(self.d_delta, width=9),
-            format_float(self.density, width=9),
+            format_float(self.delta, width=10),
+            format_float(self.d_delta, width=10),
+            format_float(self.density, width=10),
         ]
         lines.append("".join(main_parts))
 
         # Cross section points
         if self.cross_sections:
             for point in self.cross_sections:
-                lines.append("".join([" " * 10, format_float(point.energy, width=9), format_float(point.sigma, width=9)]))
+                lines.append("".join([" " * 10, format_float(point.energy, width=10), format_float(point.sigma, width=10)]))
 
         return lines
 

--- a/src/pleiades/sammy/parfile.py
+++ b/src/pleiades/sammy/parfile.py
@@ -7,8 +7,10 @@ from pydantic import BaseModel, Field
 
 from pleiades.sammy.parameters import (
     BroadeningParameterCard,
+    DataReductionCard,
     ExternalREntry,
     NormalizationBackgroundCard,
+    RadiusCard,
     ResonanceEntry,
     UnusedCorrelatedCard,
 )
@@ -24,6 +26,8 @@ class SammyParameterFile(BaseModel):
     broadening: Optional[BroadeningParameterCard] = Field(None, description="Broadening parameters")
     unused_correlated: Optional[UnusedCorrelatedCard] = Field(None, description="Unused but correlated variables")
     normalization: Optional[NormalizationBackgroundCard] = Field(None, description="Normalization and background parameters")
+    radius: Optional[RadiusCard] = Field(None, description="Radius parameters")
+    data_reduction: Optional[DataReductionCard] = Field(None, description="Data reduction parameters")
 
     @classmethod
     def from_file(cls, file_path):

--- a/src/pleiades/sammy/parfile.py
+++ b/src/pleiades/sammy/parfile.py
@@ -10,6 +10,7 @@ from pleiades.sammy.parameters import (
     DataReductionCard,
     ExternalREntry,
     NormalizationBackgroundCard,
+    ORRESCard,
     RadiusCard,
     ResonanceEntry,
     UnusedCorrelatedCard,
@@ -28,6 +29,7 @@ class SammyParameterFile(BaseModel):
     normalization: Optional[NormalizationBackgroundCard] = Field(None, description="Normalization and background parameters")
     radius: Optional[RadiusCard] = Field(None, description="Radius parameters")
     data_reduction: Optional[DataReductionCard] = Field(None, description="Data reduction parameters")
+    orres: Optional[ORRESCard] = Field(None, description="ORRES card parameters")
 
     @classmethod
     def from_file(cls, file_path):

--- a/tests/unit/pleiades/sammy/parameters/test_orres.py
+++ b/tests/unit/pleiades/sammy/parameters/test_orres.py
@@ -4,6 +4,7 @@ import pytest
 from pleiades.sammy.parameters.orres import (
     BurstParameters,
     LithiumParameters,
+    NE110Parameters,
     TantalumParameters,
     VaryFlag,
     WaterParameters,
@@ -192,6 +193,42 @@ def test_lithi_round_trip(basic_lithi_input):
         print(f"{pos:>2}: {line}")
 
     params_rt = LithiumParameters.from_lines(lines)
+    assert params_rt == params
+
+
+@pytest.fixture
+def basic_ne110_input():
+    # Col:    1----5-7-9-10-------20-------30-------40
+    return ["NE110 1 2 1.234     0.123     0.0047", "          100.0     10.0", "          200.0     20.0"]
+
+
+@pytest.fixture
+def ne110_no_cross_sections():
+    return ["NE110 0 0 1.234     0.123     0.0047"]
+
+
+def test_parse_basic_ne110(basic_ne110_input):
+    params = NE110Parameters.from_lines(basic_ne110_input)
+    assert params.delta == pytest.approx(1.234)
+    assert params.flag_delta == VaryFlag.YES
+    assert params.d_delta == pytest.approx(0.123)
+    assert params.density == pytest.approx(0.0047)
+    assert len(params.cross_sections) == 2
+    assert params.cross_sections[0].energy == pytest.approx(100.0)
+    assert params.cross_sections[0].sigma == pytest.approx(10.0)
+
+
+def test_ne110_no_cross_sections(ne110_no_cross_sections):
+    params = NE110Parameters.from_lines(ne110_no_cross_sections)
+    assert params.delta == pytest.approx(1.234)
+    assert params.flag_delta == VaryFlag.NO
+    assert params.cross_sections is None
+
+
+def test_ne110_round_trip(basic_ne110_input):
+    params = NE110Parameters.from_lines(basic_ne110_input)
+    lines = params.to_lines()
+    params_rt = NE110Parameters.from_lines(lines)
     assert params_rt == params
 
 

--- a/tests/unit/pleiades/sammy/parameters/test_orres.py
+++ b/tests/unit/pleiades/sammy/parameters/test_orres.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+import pytest
+
+from pleiades.sammy.parameters.orres import (
+    BurstParameters,
+    TantalumParameters,
+    VaryFlag,
+    WaterParameters,
+)
+
+
+@pytest.fixture
+def basic_burst_input():
+    # Column:   1----5-7--10--------20--------30
+    return ["BURST 1   12.345    0.123"]
+
+
+@pytest.fixture
+def burst_no_uncertainty():
+    # Column:   1----5-7--10--------20
+    return ["BURST 0   45.678"]
+
+
+@pytest.fixture
+def burst_with_pup():
+    # Column:   1----5-7--10--------20--------30
+    return ["BURST 3   98.765    0.246"]
+
+
+def test_parse_basic_burst(basic_burst_input):
+    params = BurstParameters.from_lines(basic_burst_input)
+    assert params.burst == pytest.approx(12.345)
+    assert params.flag_burst == VaryFlag.YES
+    assert params.d_burst == pytest.approx(0.123)
+
+
+def test_parse_burst_no_uncertainty(burst_no_uncertainty):
+    params = BurstParameters.from_lines(burst_no_uncertainty)
+    assert params.burst == pytest.approx(45.678)
+    assert params.flag_burst == VaryFlag.NO
+    assert params.d_burst is None
+
+
+def test_parse_burst_pup(burst_with_pup):
+    params = BurstParameters.from_lines(burst_with_pup)
+    assert params.burst == pytest.approx(98.765)
+    assert params.flag_burst == VaryFlag.PUP
+    assert params.d_burst == pytest.approx(0.246)
+
+
+def test_format_burst(basic_burst_input):
+    params = BurstParameters.from_lines(basic_burst_input)
+    print(params)
+    lines = params.to_lines()
+    assert len(lines) == 1
+    # Verify exact format preservation
+    params_round_trip = BurstParameters.from_lines(lines)
+    assert params_round_trip == params
+
+
+@pytest.fixture
+def basic_water_input():
+    # Col:    1----5-7-8-9-10-------20-------30-------40
+    return ["WATER 11143.614     -0.089    0.037", "          0.001     0.002     0.003"]
+
+
+@pytest.fixture
+def water_no_uncertainty():
+    return ["WATER 00043.614     -0.089    0.037"]
+
+
+@pytest.fixture
+def water_with_pup():
+    return ["WATER 33343.614     -0.089    0.037"]
+
+
+def test_parse_basic_water(basic_water_input):
+    params = WaterParameters.from_lines(basic_water_input)
+    assert params.watr0 == pytest.approx(3.614)
+    assert params.watr1 == pytest.approx(-0.089)
+    assert params.watr2 == pytest.approx(0.037)
+    assert params.flag_watr0 == VaryFlag.YES
+    assert params.flag_watr1 == VaryFlag.YES
+    assert params.flag_watr2 == VaryFlag.YES
+    assert params.d_watr0 == pytest.approx(0.001)
+    assert params.d_watr1 == pytest.approx(0.002)
+    assert params.d_watr2 == pytest.approx(0.003)
+
+
+def test_water_no_uncertainty(water_no_uncertainty):
+    params = WaterParameters.from_lines(water_no_uncertainty)
+    assert params.watr0 == pytest.approx(3.614)
+    assert params.flag_watr0 == VaryFlag.NO
+    assert params.d_watr0 is None
+
+
+def test_water_round_trip(basic_water_input):
+    params = WaterParameters.from_lines(basic_water_input)
+    lines = params.to_lines()
+
+    params_rt = WaterParameters.from_lines(lines)
+
+    assert params_rt == params
+
+
+@pytest.fixture
+def basic_tanta_input():
+    # Col:    1----5-7--10--------20--------30
+    return [
+        "TANTA 1   1.234     0.123",  # Main parameter
+        "      1110 2.345     3.456     4.567     5.678",  # Position params
+        "          0.234     0.345     0.456     0.567",  # Position uncertainties
+        "      10   7.890     8.901",  # Shape params
+        "          0.789     0.890",
+    ]  # Shape uncertainties
+
+
+@pytest.fixture
+def tanta_no_uncertainty():
+    return ["TANTA 0   1.234", "      0000 2.345     3.456     4.567     5.678", "      00   7.890     8.901"]
+
+
+def test_parse_basic_tanta(basic_tanta_input):
+    params = TantalumParameters.from_lines(basic_tanta_input)
+
+    assert params.tanta == pytest.approx(1.234)
+    assert params.flag_tanta == VaryFlag.YES
+    assert params.d_tanta == pytest.approx(0.123)
+
+    assert params.x1 == pytest.approx(2.345)
+    assert params.flag_x1 == VaryFlag.YES
+    assert params.d_x1 == pytest.approx(0.234)
+
+    assert params.beta == pytest.approx(7.890)
+    assert params.flag_beta == VaryFlag.YES
+    assert params.d_beta == pytest.approx(0.789)
+
+
+def test_tanta_no_uncertainty(tanta_no_uncertainty):
+    params = TantalumParameters.from_lines(tanta_no_uncertainty)
+
+    assert params.tanta == pytest.approx(1.234)
+    assert params.flag_tanta == VaryFlag.NO
+    assert params.d_tanta is None
+
+
+def test_tanta_round_trip(basic_tanta_input):
+    params = TantalumParameters.from_lines(basic_tanta_input)
+    lines = params.to_lines()
+    params_rt = TantalumParameters.from_lines(lines)
+    assert params_rt == params
+
+
+def test_tanta_invalid_input():
+    with pytest.raises(ValueError):
+        TantalumParameters.from_lines([])  # Empty input
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/tests/unit/pleiades/sammy/parameters/test_orres.py
+++ b/tests/unit/pleiades/sammy/parameters/test_orres.py
@@ -3,6 +3,7 @@ import pytest
 
 from pleiades.sammy.parameters.orres import (
     BurstParameters,
+    ChannelParameters,
     LithiumParameters,
     NE110Parameters,
     TantalumParameters,
@@ -230,6 +231,41 @@ def test_ne110_round_trip(basic_ne110_input):
     lines = params.to_lines()
     params_rt = NE110Parameters.from_lines(lines)
     assert params_rt == params
+
+
+@pytest.fixture
+def basic_channel_input():
+    # Col:    1----5-7--10-------20-------30-------40
+    return ["CHANN 1   100.0     1.234     0.123", "CHANN 0   200.0     2.345     0.234"]
+
+
+def test_parse_basic_channel(basic_channel_input):
+    channels = ChannelParameters.from_lines(basic_channel_input)
+    assert len(channels) == 2
+
+    assert channels[0].ecrnch == pytest.approx(100.0)
+    assert channels[0].chann == pytest.approx(1.234)
+    assert channels[0].d_chann == pytest.approx(0.123)
+    assert channels[0].flag_chann == VaryFlag.YES
+
+    assert channels[1].ecrnch == pytest.approx(200.0)
+    assert channels[1].flag_chann == VaryFlag.NO
+
+
+def test_channel_single_line():
+    lines = ["CHANN 1   100.0     1.234"]
+    channels = ChannelParameters.from_lines(lines)
+    assert len(channels) == 1
+    assert channels[0].d_chann is None
+
+
+def test_channel_round_trip(basic_channel_input):
+    channels = ChannelParameters.from_lines(basic_channel_input)
+    lines = []
+    for channel in channels:
+        lines.extend(channel.to_lines())
+    channels_rt = ChannelParameters.from_lines(lines)
+    assert channels == channels_rt
 
 
 if __name__ == "__main__":

--- a/tests/unit/pleiades/sammy/parameters/test_orres.py
+++ b/tests/unit/pleiades/sammy/parameters/test_orres.py
@@ -3,6 +3,7 @@ import pytest
 
 from pleiades.sammy.parameters.orres import (
     BurstParameters,
+    LithiumParameters,
     TantalumParameters,
     VaryFlag,
     WaterParameters,
@@ -154,6 +155,44 @@ def test_tanta_round_trip(basic_tanta_input):
 def test_tanta_invalid_input():
     with pytest.raises(ValueError):
         TantalumParameters.from_lines([])  # Empty input
+
+
+@pytest.fixture
+def basic_lithi_input():
+    # Col:    1----5-7-8-9-10-------20-------30-------40
+    return ["LITHI 111 1.234     2.345     3.456", "          0.123     0.234     0.345"]
+
+
+@pytest.fixture
+def lithi_no_uncertainty():
+    return ["LITHI 000 1.234     2.345     3.456"]
+
+
+def test_parse_basic_lithi(basic_lithi_input):
+    params = LithiumParameters.from_lines(basic_lithi_input)
+    assert params.d == pytest.approx(1.234)
+    assert params.f == pytest.approx(2.345)
+    assert params.g == pytest.approx(3.456)
+    assert params.flag_d == VaryFlag.YES
+    assert params.d_d == pytest.approx(0.123)
+
+
+def test_lithi_no_uncertainty(lithi_no_uncertainty):
+    params = LithiumParameters.from_lines(lithi_no_uncertainty)
+    assert params.d == pytest.approx(1.234)
+    assert params.flag_d == VaryFlag.NO
+    assert params.d_d is None
+
+
+def test_lithi_round_trip(basic_lithi_input):
+    params = LithiumParameters.from_lines(basic_lithi_input)
+    lines = params.to_lines()
+
+    for pos, line in enumerate(lines):
+        print(f"{pos:>2}: {line}")
+
+    params_rt = LithiumParameters.from_lines(lines)
+    assert params_rt == params
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds ORRSE card for SAMMY parameters class, along with corresponding unit test.

> EWM item: [8914](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8914)

---
AI summary
This pull request includes several updates to the `pleiades.sammy` module, focusing on adding new parameter cards and improving the formatting of floating-point numbers. Additionally, new unit tests have been introduced for the `ORRESCard` and its associated parameters.

### New Parameter Cards:
* Added imports for `DataReductionCard`, `ORRESCard`, and `RadiusCard` in `src/pleiades/sammy/parameters/__init__.py` and `src/pleiades/sammy/parfile.py`. [[1]](diffhunk://#diff-900ca65d2bad6d02d5cbcba4481c4c913adf488269b638d1d584061ccc7bad81R2-R6) [[2]](diffhunk://#diff-f15a96ecfa007c764ad2c84c7bc9f0199269ef9050e247dc7113220a9c099e2eR10-R14)
* Updated `SammyParameterFile` class to include `radius`, `data_reduction`, and `orres` fields.

### Formatting Improvements:
* Improved the `format_float` function in `src/pleiades/sammy/parameters/helper.py` to handle cases where the scientific notation does not fit the given width and to fall back to standard float format.

### Unit Tests:
* Added comprehensive unit tests for `ORRESCard` and its associated parameters (`BurstParameters`, `ChannelParameters`, `LithiumParameters`, `NE110Parameters`, `TantalumParameters`, `WaterParameters`) in `tests/unit/pleiades/sammy/parameters/test_orres.py`.