### PR TITLE
Add support for card11, misc parameter type

### DIFF
--- a/src/pleiades/sammy/parameters/misc.py
+++ b/src/pleiades/sammy/parameters/misc.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python
+#!/usr/bin/env python
+"""Parsers and containers for SAMMY's Card Set 11 parameters.
+
+This module implements parsers and containers for SAMMY's Card Set 11 miscellaneous
+parameters which can appear in either the PARameter or INPut file.
+
+Format specification from Table VI B.2:
+Card Set 11 contains optional parameter sets with distinct formats:
+
+1. DELTA - Length-dependent flight path parameters
+2. ETA - Normalization coefficients for ETA data
+3. FINIT - Finite-size corrections for angular distributions
+4. GAMMA - Radiation width specifications
+5. TZERO - Time offset parameters
+...etc.
+
+The card set starts with header "MISCEllaneous parameters follow".
+Each parameter type has a specific identifier in columns 1-5 and its own fixed-width format.
+Parameters can be omitted when not needed.
+"""
+
+import logging
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from pleiades.sammy.parameters.helper import VaryFlag, format_float, format_vary, safe_parse
+
+# Format definitions - column positions for each parameter type
+FORMAT_SPECS = {
+    "DELTA": {
+        "identifier": slice(0, 5),
+        "flag1": slice(6, 7),
+        "flag0": slice(8, 9),
+        "l1_coeff": slice(10, 20),
+        "l1_unc": slice(20, 30),
+        "l0_const": slice(30, 40),
+        "l0_unc": slice(40, 50),
+    },
+    "ETA": {"identifier": slice(0, 5), "flag": slice(6, 7), "nu_value": slice(10, 20), "nu_unc": slice(20, 30), "energy": slice(30, 40)},
+    "GAMMA": {"identifier": slice(0, 5), "group": slice(5, 7), "flag": slice(7, 9), "width": slice(10, 20), "uncertainty": slice(20, 30)},
+    "TZERO": {
+        "identifier": slice(0, 5),
+        "flag_t0": slice(6, 7),
+        "flag_l0": slice(8, 9),
+        "t0_value": slice(10, 20),
+        "t0_unc": slice(20, 30),
+        "l0_value": slice(30, 40),
+        "l0_unc": slice(40, 50),
+        "fpl": slice(50, 60),
+    },
+}
+
+
+class Card11ParameterType(str, Enum):
+    """Enumeration of Card 11 parameter types."""
+
+    DELTA = "DELTA"
+    ETA = "ETA"
+    FINIT = "FINIT"
+    GAMMA = "GAMMA"
+    TZERO = "TZERO"
+    SIABN = "SIABN"
+    SELFI = "SELFI"
+    EFFIC = "EFFIC"
+    DELTE = "DELTE"
+    DRCAP = "DRCAP"
+    NONUN = "NONUN"
+
+
+class Card11Parameter(BaseModel):
+    """Base class for Card 11 parameter types.
+
+    This class provides common functionality for all Card 11 parameter types
+    including parsing and formatting of fixed-width formats.
+
+    Attributes:
+        type (Card11ParameterType): Parameter type identifier
+    """
+
+    type: Card11ParameterType
+
+    @classmethod
+    def identify_type(cls, line: str) -> Optional[Card11ParameterType]:
+        """Identify parameter type from input line.
+
+        Args:
+            line: Input line starting with parameter identifier
+
+        Returns:
+            Parameter type or None if not recognized
+        """
+        if not line or len(line) < 5:
+            return None
+
+        identifier = line[0:5].strip()
+        try:
+            return Card11ParameterType(identifier)
+        except ValueError:
+            return None
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> Optional["Card11Parameter"]:
+        """Factory method to create appropriate parameter object.
+
+        Args:
+            lines: Input lines for parameter
+
+        Returns:
+            Parsed parameter object or None if invalid
+
+        Raises:
+            ValueError: If format is invalid
+        """
+        if not lines:
+            return None
+
+        param_type = cls.identify_type(lines[0])
+        if param_type is None:
+            return None
+
+        # Dispatch to appropriate parameter class based on type
+        parameter_classes = {
+            Card11ParameterType.DELTA: DeltaParameters,
+            # Card11ParameterType.ETA: EtaParameters,
+            # Card11ParameterType.GAMMA: GammaParameters,
+            # Card11ParameterType.TZERO: TzeroParameters,
+            # Add other parameter classes as implemented
+        }
+
+        parser_class = parameter_classes.get(param_type)
+        if parser_class is None:
+            logging.warning(f"Parser not yet implemented for parameter type: {param_type}")
+            return None
+
+        return parser_class.from_lines(lines)
+
+    def to_lines(self) -> List[str]:
+        """Convert parameter to fixed-width format lines.
+
+        Returns:
+            List of formatted lines
+
+        Raises:
+            NotImplementedError: Must be implemented by subclasses
+        """
+        raise NotImplementedError
+
+
+class DeltaParameters(Card11Parameter):
+    """Container for DELTA (Length-dependent flight path) parameters.
+
+    Format specification from Table VI B.2:
+    Cols    Format  Variable    Description
+    1-5     A       "DELTA"     Parameter identifier
+    7       I       IFLAG1      Flag for L'₁ (1=vary, 3=PUP, 0=fixed)
+    9       I       IFLAG0      Flag for L'₀
+    11-20   F       DELL11      L'₁ coefficient of E (m/eV)
+    21-30   F       D1          Uncertainty on L'₁ (m/eV)
+    31-40   F       DELL00      L'₀ constant term (m)
+    41-50   F       D0          Uncertainty on L'₀ (m)
+
+    Attributes:
+        l1_coefficient: L'₁ coefficient of E (m/eV)
+        l1_uncertainty: Uncertainty on L'₁ (m/eV)
+        l0_constant: L'₀ constant term (m)
+        l0_uncertainty: Uncertainty on L'₀ (m)
+        l1_flag: Flag for varying L'₁
+        l0_flag: Flag for varying L'₀
+    """
+
+    type: Card11ParameterType = Card11ParameterType.DELTA
+    l1_coefficient: float = Field(..., description="L'₁ coefficient of E (m/eV)")
+    l1_uncertainty: Optional[float] = Field(None, description="Uncertainty on L'₁ (m/eV)")
+    l0_constant: float = Field(..., description="L'₀ constant term (m)")
+    l0_uncertainty: Optional[float] = Field(None, description="Uncertainty on L'₀ (m)")
+    l1_flag: VaryFlag = Field(default=VaryFlag.NO, description="Flag for L'₁")
+    l0_flag: VaryFlag = Field(default=VaryFlag.NO, description="Flag for L'₀")
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "DeltaParameters":
+        """Parse DELTA parameters from fixed-width format lines.
+
+        Args:
+            lines: List of input lines (expects single line for DELTA parameters)
+
+        Returns:
+            DeltaParameters: Parsed parameters
+
+        Raises:
+            ValueError: If format is invalid or required values missing
+        """
+        if not lines or not lines[0].strip():
+            raise ValueError("No valid parameter line provided")
+
+        # Verify identifier
+        line = f"{lines[0]:<80}"  # Pad to full width
+        identifier = line[FORMAT_SPECS["DELTA"]["identifier"]].strip()
+        if identifier != "DELTA":
+            raise ValueError(f"Invalid identifier: {identifier}")
+
+        # Parse flags
+        try:
+            l1_flag = VaryFlag(int(line[FORMAT_SPECS["DELTA"]["flag1"]].strip() or "0"))
+            l0_flag = VaryFlag(int(line[FORMAT_SPECS["DELTA"]["flag0"]].strip() or "0"))
+        except ValueError as e:
+            raise ValueError(f"Invalid flag value: {e}")
+
+        # Parse required numeric values
+        l1_coeff = safe_parse(line[FORMAT_SPECS["DELTA"]["l1_coeff"]])
+        l0_const = safe_parse(line[FORMAT_SPECS["DELTA"]["l0_const"]])
+
+        if l1_coeff is None or l0_const is None:
+            raise ValueError("Missing required numeric values")
+
+        # Parse optional uncertainties
+        l1_unc = safe_parse(line[FORMAT_SPECS["DELTA"]["l1_unc"]])
+        l0_unc = safe_parse(line[FORMAT_SPECS["DELTA"]["l0_unc"]])
+
+        return cls(
+            l1_coefficient=l1_coeff, l1_uncertainty=l1_unc, l0_constant=l0_const, l0_uncertainty=l0_unc, l1_flag=l1_flag, l0_flag=l0_flag
+        )
+
+    def to_lines(self) -> List[str]:
+        """Convert parameters to fixed-width format line.
+
+        Returns:
+            List containing single formatted line
+        """
+        parts = [
+            "DELTA".ljust(5),
+            " ",  # Column 6 spacing
+            format_vary(self.l1_flag),
+            " ",  # Column 8 spacing
+            format_vary(self.l0_flag),
+            " ",  # Column 10 spacing
+            format_float(self.l1_coefficient, width=10),
+            format_float(self.l1_uncertainty, width=10),
+            format_float(self.l0_constant, width=10),
+            format_float(self.l0_uncertainty, width=10),
+        ]
+        return ["".join(parts)]
+
+
+class EtaParameters(Card11Parameter):
+    """Container for ETA (normalization coefficient) parameters.
+
+    Format specification from Table VI B.2:
+    Cols    Format  Variable    Description
+    1-5     A       "ETA "      Parameter identifier ("eta" + 2 spaces)
+    7       I       IFLAGN      Flag for parameter ν (0=fixed, 1=vary, 3=PUP)
+    11-20   F       NU          Normalization coefficient ν (dimensionless)
+    21-30   F       DNU         Uncertainty on NU
+    31-40   F       ENU         Energy for which this value applies (eV)
+
+    Notes:
+    - If a constant value of NU is wanted, the energy value can be omitted
+    - If more than one ETA line is present, all must be together in increasing energy order
+    - SAMMY will linearly interpolate to obtain values between specified energies
+
+    Attributes:
+        nu_value: Normalization coefficient ν (dimensionless)
+        nu_uncertainty: Uncertainty on ν
+        energy: Energy for which this value applies (eV), optional
+        flag: Flag for varying ν
+    """
+
+    type: Card11ParameterType = Card11ParameterType.ETA
+    nu_value: float = Field(..., description="Normalization coefficient ν")
+    nu_uncertainty: Optional[float] = Field(None, description="Uncertainty on ν")
+    energy: Optional[float] = Field(None, description="Energy value (eV)")
+    flag: VaryFlag = Field(default=VaryFlag.NO, description="Flag for ν")
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "EtaParameters":
+        """Parse ETA parameters from fixed-width format lines.
+
+        Args:
+            lines: List of input lines (expects single line for ETA parameters)
+
+        Returns:
+            EtaParameters: Parsed parameters
+
+        Raises:
+            ValueError: If format is invalid or required values missing
+        """
+        if not lines or not lines[0].strip():
+            raise ValueError("No valid parameter line provided")
+
+        line = f"{lines[0]:<80}"  # Pad to full width
+
+        # Verify identifier is "ETA " (including 2 spaces)
+        identifier = line[FORMAT_SPECS["ETA"]["identifier"]].strip()
+        if identifier != "ETA":
+            raise ValueError(f"Invalid identifier: {identifier}")
+
+        # Parse flag
+        try:
+            flag = VaryFlag(int(line[FORMAT_SPECS["ETA"]["flag"]].strip() or "0"))
+        except ValueError as e:
+            raise ValueError(f"Invalid flag value: {e}")
+
+        # Parse required nu value
+        nu_value = safe_parse(line[FORMAT_SPECS["ETA"]["nu_value"]])
+        if nu_value is None:
+            raise ValueError("Missing required nu value")
+
+        # Parse optional values
+        nu_unc = safe_parse(line[FORMAT_SPECS["ETA"]["nu_unc"]])
+        energy = safe_parse(line[FORMAT_SPECS["ETA"]["energy"]])
+
+        return cls(nu_value=nu_value, nu_uncertainty=nu_unc, energy=energy, flag=flag)
+
+    def to_lines(self) -> List[str]:
+        """Convert parameters to fixed-width format line.
+
+        Returns:
+            List containing single formatted line
+        """
+        parts = [
+            "ETA ".ljust(5),  # Identifier with required 2 spaces
+            " ",  # Column 6 spacing
+            format_vary(self.flag),
+            "   ",  # Columns 8-10 spacing
+            format_float(self.nu_value, width=10),
+            format_float(self.nu_uncertainty, width=10),
+            format_float(self.energy, width=10) if self.energy is not None else " " * 10,
+        ]
+        return ["".join(parts)]
+
+
+if __name__ == "__main__":
+    print("Refer to unit tests for usage examples.")

--- a/src/pleiades/sammy/parameters/misc.py
+++ b/src/pleiades/sammy/parameters/misc.py
@@ -40,6 +40,15 @@ FORMAT_SPECS = {
         "l0_unc": slice(40, 50),
     },
     "ETA": {"identifier": slice(0, 5), "flag": slice(6, 7), "nu_value": slice(10, 20), "nu_unc": slice(20, 30), "energy": slice(30, 40)},
+    "FINIT": {
+        "identifier": slice(0, 5),
+        "flag_i": slice(6, 7),
+        "flag_o": slice(8, 9),
+        "attni": slice(10, 20),
+        "dttni": slice(20, 30),
+        "attno": slice(30, 40),
+        "dttno": slice(40, 50),
+    },
     "GAMMA": {"identifier": slice(0, 5), "group": slice(5, 7), "flag": slice(7, 9), "width": slice(10, 20), "uncertainty": slice(20, 30)},
     "TZERO": {
         "identifier": slice(0, 5),
@@ -50,6 +59,61 @@ FORMAT_SPECS = {
         "l0_value": slice(30, 40),
         "l0_unc": slice(40, 50),
         "fpl": slice(50, 60),
+    },
+    "SIABN": {
+        "identifier": slice(0, 5),
+        "flag1": slice(6, 7),
+        "flag2": slice(8, 9),
+        "flag3": slice(9, 10),
+        "abundance1": slice(10, 20),
+        "uncertainty1": slice(20, 30),
+        "abundance2": slice(30, 40),
+        "uncertainty2": slice(40, 50),
+        "abundance3": slice(50, 60),
+        "uncertainty3": slice(60, 70),
+    },
+    "SELFI": {
+        "identifier": slice(0, 5),
+        "flag_temp": slice(6, 7),
+        "flag_thick": slice(8, 9),
+        "temperature": slice(10, 20),
+        "temp_unc": slice(20, 30),
+        "thickness": slice(30, 40),
+        "thick_unc": slice(40, 50),
+    },
+    "EFFIC": {
+        "identifier": slice(0, 5),
+        "flag_cap": slice(6, 7),
+        "flag_fis": slice(8, 9),
+        "eff_cap": slice(10, 20),
+        "eff_fis": slice(20, 30),
+        "eff_cap_unc": slice(30, 40),
+        "eff_fis_unc": slice(40, 50),
+    },
+    "DELTE": {
+        "identifier": slice(0, 5),
+        "flag1": slice(6, 7),
+        "flag0": slice(8, 9),
+        "flagl": slice(9, 10),
+        "dele1": slice(10, 20),
+        "dd1": slice(20, 30),
+        "dele0": slice(30, 40),
+        "dd0": slice(40, 50),
+        "delel": slice(50, 60),
+        "ddl": slice(60, 70),
+    },
+    "DRCAP": {
+        "identifier": slice(0, 5),
+        "flag1": slice(6, 7),
+        "nuc": slice(8, 9),
+        "coef": slice(10, 20),
+        "dcoef": slice(20, 30),
+    },
+    "NONUN": {
+        "identifier": slice(0, 5),
+        "radius": slice(20, 30),
+        "thickness": slice(30, 40),
+        "uncertainty": slice(40, 50),
     },
 }
 
@@ -327,6 +391,201 @@ class EtaParameters(Card11Parameter):
             format_float(self.nu_value, width=10),
             format_float(self.nu_uncertainty, width=10),
             format_float(self.energy, width=10) if self.energy is not None else " " * 10,
+        ]
+        return ["".join(parts)]
+
+
+class FinitParameters(Card11Parameter):
+    """Container for FINIT (finite-size corrections) parameters.
+
+    Format specification from Table VI B.2:
+    Cols  Format  Variable    Description
+    1-5   A       "FINIT"     Parameter identifier
+    7     I       IFLAGI      Flag for ATTNI
+    9     I       IFLAGO      Flag for ATTNO
+    11-20  F       ATTNI       Incident-particle attenuation (atoms/barn)
+    21-30  F       DTTNI       Uncertainty on ATTNI
+    31-40  F       ATTNO       Exit-particle attenuation (atom/b)
+    41-50  F       DTTNO       Uncertainty on ATTNO
+
+    Notes:
+    - Repeat once for each angle
+    - If only one line, same attenuations used for all angles
+
+    Attributes:
+        incident_attenuation: Incident-particle attenuation (atoms/barn)
+        incident_uncertainty: Uncertainty on incident attenuation
+        exit_attenuation: Exit-particle attenuation (atom/b)
+        exit_uncertainty: Uncertainty on exit attenuation
+        incident_flag: Flag for incident attenuation
+        exit_flag: Flag for exit attenuation
+    """
+
+    type: Card11ParameterType = Card11ParameterType.FINIT
+    incident_attenuation: float = Field(..., description="Incident-particle attenuation (atoms/barn)")
+    incident_uncertainty: Optional[float] = Field(None, description="Uncertainty on incident attenuation")
+    exit_attenuation: float = Field(..., description="Exit-particle attenuation (atom/b)")
+    exit_uncertainty: Optional[float] = Field(None, description="Uncertainty on exit attenuation")
+    incident_flag: VaryFlag = Field(default=VaryFlag.NO, description="Flag for incident attenuation")
+    exit_flag: VaryFlag = Field(default=VaryFlag.NO, description="Flag for exit attenuation")
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "FinitParameters":
+        """Parse FINIT parameters from fixed-width format lines.
+
+        Args:
+            lines: List of input lines (expects single line for FINIT parameters)
+
+        Returns:
+            FinitParameters: Parsed parameters
+
+        Raises:
+            ValueError: If format is invalid or required values missing
+        """
+        if not lines or not lines[0].strip():
+            raise ValueError("No valid parameter line provided")
+
+        line = f"{lines[0]:<80}"  # Pad to full width
+
+        # Verify identifier
+        identifier = line[FORMAT_SPECS["FINIT"]["identifier"]].strip()
+        if identifier != "FINIT":
+            raise ValueError(f"Invalid identifier: {identifier}")
+
+        # Parse flags
+        try:
+            incident_flag = VaryFlag(int(line[FORMAT_SPECS["FINIT"]["flag_i"]].strip() or "0"))
+            exit_flag = VaryFlag(int(line[FORMAT_SPECS["FINIT"]["flag_o"]].strip() or "0"))
+        except ValueError as e:
+            raise ValueError(f"Invalid flag value: {e}")
+
+        # Parse required attenuations
+        incident_att = safe_parse(line[FORMAT_SPECS["FINIT"]["attni"]])
+        exit_att = safe_parse(line[FORMAT_SPECS["FINIT"]["attno"]])
+
+        if incident_att is None or exit_att is None:
+            raise ValueError("Missing required attenuation values")
+
+        # Parse optional uncertainties
+        incident_unc = safe_parse(line[FORMAT_SPECS["FINIT"]["dttni"]])
+        exit_unc = safe_parse(line[FORMAT_SPECS["FINIT"]["dttno"]])
+
+        return cls(
+            incident_attenuation=incident_att,
+            incident_uncertainty=incident_unc,
+            exit_attenuation=exit_att,
+            exit_uncertainty=exit_unc,
+            incident_flag=incident_flag,
+            exit_flag=exit_flag,
+        )
+
+    def to_lines(self) -> List[str]:
+        """Convert parameters to fixed-width format line.
+
+        Returns:
+            List containing single formatted line
+        """
+        parts = [
+            "FINIT",  # Identifier
+            " ",  # Column 6 spacing
+            format_vary(self.incident_flag),  # Col 7
+            " ",  # Column 8 spacing
+            format_vary(self.exit_flag),  # Col 9
+            " ",  # Column 10 spacing
+            format_float(self.incident_attenuation, width=10),
+            format_float(self.incident_uncertainty, width=10),
+            format_float(self.exit_attenuation, width=10),
+            format_float(self.exit_uncertainty, width=10),
+        ]
+        return ["".join(parts)]
+
+
+class GammaParameters(Card11Parameter):
+    """Container for GAMMA (radiation width) parameters.
+
+    Format specification from Table VI B.2:
+    Cols  Format  Variable    Description
+    1-5   A       "GAMMA"     Parameter identifier
+    6-7   I       IG          Spin group number
+    8-9   I       IFG         Flag for GAMGAM (0=fixed, 1=vary, 3=PUP)
+    11-20  F       GAMGAM      Radiation width Γγ for all resonances in spin group
+    21-30  F       DGAM        Uncertainty on GAMGAM
+
+    Notes:
+    - If used for any spin group, must be given for every spin group
+
+    Attributes:
+        spin_group: Spin group number (must be positive)
+        width: Radiation width Γγ for all resonances in group
+        uncertainty: Uncertainty on width (optional)
+        flag: Flag for varying width
+    """
+
+    type: Card11ParameterType = Card11ParameterType.GAMMA
+    spin_group: int = Field(..., gt=0, description="Spin group number")
+    width: float = Field(..., description="Radiation width Γγ")
+    uncertainty: Optional[float] = Field(None, description="Uncertainty on width")
+    flag: VaryFlag = Field(default=VaryFlag.NO, description="Flag for width")
+
+    @classmethod
+    def from_lines(cls, lines: List[str]) -> "GammaParameters":
+        """Parse GAMMA parameters from fixed-width format lines.
+
+        Args:
+            lines: List of input lines (expects single line for GAMMA parameters)
+
+        Returns:
+            GammaParameters: Parsed parameters
+
+        Raises:
+            ValueError: If format is invalid or required values missing
+        """
+        if not lines or not lines[0].strip():
+            raise ValueError("No valid parameter line provided")
+
+        line = f"{lines[0]:<80}"  # Pad to full width
+
+        # Verify identifier
+        identifier = line[FORMAT_SPECS["GAMMA"]["identifier"]].strip()
+        if identifier != "GAMMA":
+            raise ValueError(f"Invalid identifier: {identifier}")
+
+        # Parse spin group (required)
+        spin_group = safe_parse(line[FORMAT_SPECS["GAMMA"]["group"]], as_int=True)
+        if spin_group is None:
+            raise ValueError("Missing or invalid spin group number")
+        if spin_group <= 0:
+            raise ValueError("Spin group must be positive")
+
+        # Parse flag
+        try:
+            flag = VaryFlag(int(line[FORMAT_SPECS["GAMMA"]["flag"]].strip() or "0"))
+        except ValueError as e:
+            raise ValueError(f"Invalid flag value: {e}")
+
+        # Parse width (required)
+        width = safe_parse(line[FORMAT_SPECS["GAMMA"]["width"]])
+        if width is None:
+            raise ValueError("Missing required width value")
+
+        # Parse optional uncertainty
+        uncertainty = safe_parse(line[FORMAT_SPECS["GAMMA"]["uncertainty"]])
+
+        return cls(spin_group=spin_group, width=width, uncertainty=uncertainty, flag=flag)
+
+    def to_lines(self) -> List[str]:
+        """Convert parameters to fixed-width format line.
+
+        Returns:
+            List containing single formatted line
+        """
+        parts = [
+            "GAMMA",  # Identifier
+            str(self.spin_group).rjust(2),  # Spin group (cols 6-7)
+            format_vary(self.flag).rjust(2),  # Flag (cols 8-9)
+            " ",  # Column 10 spacing
+            format_float(self.width, width=10),  # Width (cols 11-20)
+            format_float(self.uncertainty, width=10),  # Uncertainty (cols 21-30)
         ]
         return ["".join(parts)]
 

--- a/src/pleiades/sammy/parameters/misc.py
+++ b/src/pleiades/sammy/parameters/misc.py
@@ -601,32 +601,32 @@ class TzeroParameters(Card11Parameter):
     Format specification from Table VI B.2:
     Cols  Format  Variable    Description
     1-5   A       "TZERO"     Parameter identifier
-    7     I       IFTZER      Flag for t₀
-    9     I       IFLZER      Flag for L₀
-    11-20 F       TZERO       t₀ (μs)
-    21-30 F       DTZERO      Uncertainty on t₀ (μs)
-    31-40 F       LZERO       L₀ (dimensionless)
-    41-50 F       DLZERO      Uncertainty on L₀
+    7     I       IFTZER      Flag for t
+    9     I       IFLZER      Flag for L
+    11-20 F       TZERO       t (μs)
+    21-30 F       DTZERO      Uncertainty on t (μs)
+    31-40 F       LZERO       L (dimensionless)
+    41-50 F       DLZERO      Uncertainty on L
     51-60 F       FPL         Flight-path length (m)
 
     Attributes:
-        t0_value: Time offset t₀ (μs)
-        t0_uncertainty: Uncertainty on t₀ (μs)
-        l0_value: L₀ value (dimensionless)
-        l0_uncertainty: Uncertainty on L₀
+        t0_value: Time offset t (μs)
+        t0_uncertainty: Uncertainty on t (μs)
+        l0_value: L value (dimensionless)
+        l0_uncertainty: Uncertainty on L
         flight_path_length: Flight path length (m), optional
-        t0_flag: Flag for varying t₀
-        l0_flag: Flag for varying L₀
+        t0_flag: Flag for varying t
+        l0_flag: Flag for varying L
     """
 
     type: Card11ParameterType = Card11ParameterType.TZERO
-    t0_value: float = Field(..., description="Time offset t₀ (μs)")
-    t0_uncertainty: Optional[float] = Field(None, description="Uncertainty on t₀ (μs)")
-    l0_value: float = Field(..., description="L₀ value (dimensionless)")
-    l0_uncertainty: Optional[float] = Field(None, description="Uncertainty on L₀")
+    t0_value: float = Field(..., description="Time offset t (μs)")
+    t0_uncertainty: Optional[float] = Field(None, description="Uncertainty on t (μs)")
+    l0_value: float = Field(..., description="L value (dimensionless)")
+    l0_uncertainty: Optional[float] = Field(None, description="Uncertainty on L")
     flight_path_length: Optional[float] = Field(None, description="Flight path length (m)")
-    t0_flag: VaryFlag = Field(default=VaryFlag.NO, description="Flag for t₀")
-    l0_flag: VaryFlag = Field(default=VaryFlag.NO, description="Flag for L₀")
+    t0_flag: VaryFlag = Field(default=VaryFlag.NO, description="Flag for t")
+    l0_flag: VaryFlag = Field(default=VaryFlag.NO, description="Flag for L")
 
     @classmethod
     def from_lines(cls, lines: List[str]) -> "TzeroParameters":
@@ -693,10 +693,10 @@ class TzeroParameters(Card11Parameter):
             " ",  # Column 8 spacing
             format_vary(self.l0_flag),  # Col 9
             " ",  # Column 10 spacing
-            format_float(self.t0_value, width=10),  # t₀ value
-            format_float(self.t0_uncertainty, width=10),  # t₀ uncertainty
-            format_float(self.l0_value, width=10),  # L₀ value
-            format_float(self.l0_uncertainty, width=10),  # L₀ uncertainty
+            format_float(self.t0_value, width=10),  # t value
+            format_float(self.t0_uncertainty, width=10),  # t uncertainty
+            format_float(self.l0_value, width=10),  # L value
+            format_float(self.l0_uncertainty, width=10),  # L uncertainty
             format_float(self.flight_path_length, width=10),  # Flight path length
         ]
         return ["".join(parts)]

--- a/tests/unit/pleiades/sammy/parameters/test_misc.py
+++ b/tests/unit/pleiades/sammy/parameters/test_misc.py
@@ -7,6 +7,8 @@ from pleiades.sammy.parameters.helper import VaryFlag
 from pleiades.sammy.parameters.misc import (
     DeltaParameters,
     EtaParameters,
+    FinitParameters,
+    GammaParameters,
 )
 
 
@@ -148,6 +150,181 @@ class TestEtaParameters:
         line = "ETA   1    1.234E+00 2.345E-03"  # No energy value
         params = EtaParameters.from_lines([line])
         assert params.energy is None
+
+
+class TestFinitParameters:
+    """Test suite for FINIT parameter parsing and formatting.
+
+    FINIT parameters specify finite-size corrections for angular distributions:
+    Cols  Format  Variable    Description
+    1-5   A       "FINIT"     Parameter identifier
+    7     I       IFLAGI      Flag for ATTNI
+    9     I       IFLAGO      Flag for ATTNO
+    11-20  F       ATTNI       Incident-particle attenuation (atoms/barn)
+    21-30  F       DTTNI       Uncertainty on ATTNI
+    31-40  F       ATTNO       Exit-particle attenuation (atom/b)
+    41-50  F       DTTNO       Uncertainty on ATTNO
+
+    Notes:
+    - Repeat once for each angle
+    - If only one line, same attenuations used for all angles
+    """
+
+    @pytest.fixture
+    def valid_finit_line(self):
+        """Sample valid FINIT parameter line."""
+        return "FINIT 1 1 1.234E+00 2.345E-03 3.456E+00 4.567E-03"
+        #       |     | | |         |         |         |
+        #       |     | | |         |         |         41-50: DTTNO uncertainty
+        #       |     | | |         |         31-40: ATTNO exit attenuation
+        #       |     | | |         21-30: DTTNI uncertainty
+        #       |     | | 11-20: ATTNI incident attenuation
+        #       |     | 9: ATTNO flag
+        #       |     7: ATTNI flag
+        #       1-5: "FINIT"
+
+    @pytest.fixture
+    def valid_finit_params(self):
+        """Sample valid FINIT parameters."""
+        return FinitParameters(
+            incident_attenuation=1.234,
+            incident_uncertainty=2.345e-3,
+            exit_attenuation=3.456,
+            exit_uncertainty=4.567e-3,
+            incident_flag=VaryFlag.YES,
+            exit_flag=VaryFlag.YES,
+        )
+
+    def test_parse_valid_line(self, valid_finit_line):
+        """Test parsing of valid FINIT parameter line."""
+        # check col number for each char
+        for i, char in enumerate(valid_finit_line):
+            print(f"{i+1}: {char}")
+
+        params = FinitParameters.from_lines([valid_finit_line])
+        assert params.incident_attenuation == pytest.approx(1.234)
+        assert params.incident_uncertainty == pytest.approx(2.345e-3)
+        assert params.exit_attenuation == pytest.approx(3.456)
+        assert params.exit_uncertainty == pytest.approx(4.567e-3)
+        assert params.incident_flag == VaryFlag.YES
+        assert params.exit_flag == VaryFlag.YES
+
+    def test_round_trip(self, valid_finit_params):
+        """Test round-trip parsing and formatting of FINIT parameters."""
+        lines = valid_finit_params.to_lines()
+        assert len(lines) == 1
+        params = FinitParameters.from_lines(lines)
+        assert params == valid_finit_params
+
+    @pytest.mark.parametrize(
+        "invalid_line",
+        [
+            "",  # Empty line
+            "FINIT x 1 1.234E+00 2.345E-03 3.456E+00 4.567E-03",  # Invalid incident flag
+            "FINIT 1 x 1.234E+00 2.345E-03 3.456E+00 4.567E-03",  # Invalid exit flag
+            "FINIT 1 1 invalid   2.345E-03 3.456E+00 4.567E-03",  # Invalid incident attenuation
+            "FINIT 1 1 1.234E+00 2.345E-03 invalid   4.567E-03",  # Invalid exit attenuation
+            "FINIX 1 1 1.234E+00 2.345E-03 3.456E+00 4.567E-03",  # Wrong identifier
+        ],
+    )
+    def test_parse_invalid_lines(self, invalid_line):
+        """Test parsing of invalid FINIT parameter lines."""
+        with pytest.raises(ValueError):
+            FinitParameters.from_lines([invalid_line])
+
+    def test_required_values(self):
+        """Test that required values must be provided."""
+        with pytest.raises(ValueError):
+            FinitParameters(
+                incident_attenuation=None,  # Required
+                exit_attenuation=3.456,
+                incident_flag=VaryFlag.YES,
+                exit_flag=VaryFlag.YES,
+            )
+
+
+class TestGammaParameters:
+    """Test suite for GAMMA parameter parsing and formatting.
+
+    GAMMA parameters specify radiation width for spin groups:
+    Cols  Format  Variable    Description
+    1-5   A       "GAMMA"     Parameter identifier
+    6-7   I       IG          Spin group number
+    8-9   I       IFG         Flag for GAMGAM (0=fixed, 1=vary, 3=PUP)
+    11-20  F       GAMGAM      Radiation width Γγ for all resonances in spin group
+    21-30  F       DGAM        Uncertainty on GAMGAM
+
+    Notes:
+    - If used for any spin group, must be given for every spin group
+    """
+
+    @pytest.fixture
+    def valid_gamma_line(self):
+        """Sample valid GAMMA parameter line."""
+        return "GAMMA 1 1 1.234E+00 2.345E-03"
+        #       |     | | |         |
+        #       |     | | |         21-30: Uncertainty
+        #       |     | | 11-20: Width value
+        #       |     | 8-9: Flag
+        #       |     6-7: Spin group
+        #       1-5: "GAMMA"
+
+    @pytest.fixture
+    def valid_gamma_params(self):
+        """Sample valid GAMMA parameters."""
+        return GammaParameters(spin_group=1, width=1.234, uncertainty=2.345e-3, flag=VaryFlag.YES)
+
+    def test_parse_valid_line(self, valid_gamma_line):
+        """Test parsing of valid GAMMA parameter line."""
+        # check col number for each char
+        for i, char in enumerate(valid_gamma_line):
+            print(f"{i+1}: {char}")
+
+        params = GammaParameters.from_lines([valid_gamma_line])
+        assert params.spin_group == 1
+        assert params.width == pytest.approx(1.234)
+        assert params.uncertainty == pytest.approx(2.345e-3)
+        assert params.flag == VaryFlag.YES
+
+    def test_round_trip(self, valid_gamma_params):
+        """Test round-trip parsing and formatting of GAMMA parameters."""
+        lines = valid_gamma_params.to_lines()
+        assert len(lines) == 1
+        params = GammaParameters.from_lines(lines)
+        assert params == valid_gamma_params
+
+    @pytest.mark.parametrize(
+        "invalid_line",
+        [
+            "",  # Empty line
+            "GAMMA x 1 1.234E+00 2.345E-03",  # Invalid spin group
+            "GAMMA 1 x 1.234E+00 2.345E-03",  # Invalid flag
+            "GAMMA 1 1 invalid   2.345E-03",  # Invalid width
+            "GAMMX 1 1 1.234E+00 2.345E-03",  # Wrong identifier
+        ],
+    )
+    def test_parse_invalid_lines(self, invalid_line):
+        """Test parsing of invalid GAMMA parameter lines."""
+        with pytest.raises(ValueError):
+            GammaParameters.from_lines([invalid_line])
+
+    def test_required_values(self):
+        """Test that required values must be provided."""
+        with pytest.raises(ValueError):
+            GammaParameters(
+                spin_group=1,
+                width=None,  # Required
+                flag=VaryFlag.YES,
+            )
+
+    def test_spin_group_range(self):
+        """Test spin group number validation."""
+        with pytest.raises(ValueError, match="Input should be greater than 0"):
+            GammaParameters(
+                spin_group=0,  # Invalid
+                width=1.234,
+                flag=VaryFlag.YES,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit/pleiades/sammy/parameters/test_misc.py
+++ b/tests/unit/pleiades/sammy/parameters/test_misc.py
@@ -340,12 +340,12 @@ class TestTzeroParameters:
     TZERO parameters specify time offset and flight path parameters:
     Cols  Format  Variable    Description
     1-5   A       "TZERO"     Parameter identifier
-    7     I       IFTZER      Flag for t₀
-    9     I       IFLZER      Flag for L₀
-    11-20 F       TZERO       t₀ (μs)
-    21-30 F       DTZERO      Uncertainty on t₀ (μs)
-    31-40 F       LZERO       L₀ (dimensionless)
-    41-50 F       DLZERO      Uncertainty on L₀
+    7     I       IFTZER      Flag for t
+    9     I       IFLZER      Flag for L
+    11-20 F       TZERO       t (μs)
+    21-30 F       DTZERO      Uncertainty on t (μs)
+    31-40 F       LZERO       L (dimensionless)
+    41-50 F       DLZERO      Uncertainty on L
     51-60 F       FPL         Flight-path length (m)
     """
 
@@ -355,12 +355,12 @@ class TestTzeroParameters:
         return "TZERO 1 1 1.234E+00 2.345E-03 3.456E+00 4.567E-03 5.678E+01"
         #       |     | | |         |         |         |         |
         #       |     | | |         |         |         |         51-60: Flight-path length
-        #       |     | | |         |         |         41-50: L₀ uncertainty
-        #       |     | | |         |         31-40: L₀ value
-        #       |     | | |         21-30: t₀ uncertainty
-        #       |     | | 11-20: t₀ value
-        #       |     | 9: L₀ flag
-        #       |     7: t₀ flag
+        #       |     | | |         |         |         41-50: L uncertainty
+        #       |     | | |         |         31-40: L value
+        #       |     | | |         21-30: t uncertainty
+        #       |     | | 11-20: t value
+        #       |     | 9: L flag
+        #       |     7: t flag
         #       1-5: "TZERO"
 
     @pytest.fixture
@@ -402,10 +402,10 @@ class TestTzeroParameters:
         "invalid_line",
         [
             "",  # Empty line
-            "TZERO x 1 1.234E+00 2.345E-03 3.456E+00 4.567E-03 5.678E+01",  # Invalid t₀ flag
-            "TZERO 1 x 1.234E+00 2.345E-03 3.456E+00 4.567E-03 5.678E+01",  # Invalid L₀ flag
-            "TZERO 1 1 invalid   2.345E-03 3.456E+00 4.567E-03 5.678E+01",  # Invalid t₀ value
-            "TZERO 1 1 1.234E+00 2.345E-03 invalid   4.567E-03 5.678E+01",  # Invalid L₀ value
+            "TZERO x 1 1.234E+00 2.345E-03 3.456E+00 4.567E-03 5.678E+01",  # Invalid t flag
+            "TZERO 1 x 1.234E+00 2.345E-03 3.456E+00 4.567E-03 5.678E+01",  # Invalid L flag
+            "TZERO 1 1 invalid   2.345E-03 3.456E+00 4.567E-03 5.678E+01",  # Invalid t value
+            "TZERO 1 1 1.234E+00 2.345E-03 invalid   4.567E-03 5.678E+01",  # Invalid L value
             "TZERX 1 1 1.234E+00 2.345E-03 3.456E+00 4.567E-03 5.678E+01",  # Wrong identifier
         ],
     )

--- a/tests/unit/pleiades/sammy/parameters/test_misc.py
+++ b/tests/unit/pleiades/sammy/parameters/test_misc.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+"""Unit tests for Card Set 11 (Miscellaneous Parameters) parsing."""
+
+import pytest
+
+from pleiades.sammy.parameters.helper import VaryFlag
+from pleiades.sammy.parameters.misc import (
+    DeltaParameters,
+    EtaParameters,
+)
+
+
+class TestDeltaParameters:
+    """Test suite for DELTA parameter parsing and formatting."""
+
+    @pytest.fixture
+    def valid_delta_line(self):
+        """Sample valid DELTA parameter line."""
+        return "DELTA 1 0 1.234E+00 2.345E-03 3.456E+00 4.567E-03"
+
+    @pytest.fixture
+    def valid_delta_params(self):
+        """Sample valid DELTA parameters."""
+        return DeltaParameters(
+            l1_coefficient=1.234,
+            l1_uncertainty=2.345e-3,
+            l0_constant=3.456,
+            l0_uncertainty=4.567e-3,
+            l1_flag=VaryFlag.YES,
+            l0_flag=VaryFlag.NO,
+        )
+
+    def test_parse_valid_line(self, valid_delta_line):
+        """Test parsing of valid DELTA parameter line."""
+        # check col number for each char
+        for i, char in enumerate(valid_delta_line):
+            print(f"{i}: {char}")
+
+        params = DeltaParameters.from_lines([valid_delta_line])
+        assert params.l1_coefficient == pytest.approx(1.234)
+        assert params.l1_uncertainty == pytest.approx(2.345e-3)
+        assert params.l0_constant == pytest.approx(3.456)
+        assert params.l0_uncertainty == pytest.approx(4.567e-3)
+        assert params.l1_flag == VaryFlag.YES
+        assert params.l0_flag == VaryFlag.NO
+
+    def test_round_trip(self, valid_delta_params):
+        """Test round-trip parsing and formatting of DELTA parameters."""
+        lines = valid_delta_params.to_lines()
+        assert len(lines) == 1
+
+        params = DeltaParameters.from_lines(lines)
+        assert params == valid_delta_params
+
+    @pytest.mark.parametrize(
+        "invalid_line",
+        [
+            "",  # Empty line
+            "WRONG 1 0  1.234E+00  2.345E-03  3.456E+00  4.567E-03",  # Wrong identifier
+            "DELTA x 0  1.234E+00  2.345E-03  3.456E+00  4.567E-03",  # Invalid flag
+            "DELTA 1 0  invalid     2.345E-03  3.456E+00  4.567E-03",  # Invalid number
+        ],
+    )
+    def test_parse_invalid_lines(self, invalid_line):
+        """Test parsing of invalid DELTA parameter lines."""
+        with pytest.raises(ValueError):
+            DeltaParameters.from_lines([invalid_line])
+
+    def test_required_values(self):
+        """Test that required values must be provided."""
+        with pytest.raises(ValueError):
+            DeltaParameters(
+                l1_coefficient=None,  # Required
+                l0_constant=3.456,
+            )
+
+
+class TestEtaParameters:
+    """Test suite for ETA parameter parsing and formatting.
+
+    ETA parameters define normalization coefficients and have format:
+    1-5     A       "ETA "      Parameter identifier ("eta" + 2 spaces)
+    7       I       IFLAGN      Flag for parameter ν
+    11-20   F       NU          Normalization coefficient ν
+    21-30   F       DNU         Uncertainty on NU
+    31-40   F       ENU         Energy for which this value applies (eV)
+    """
+
+    @pytest.fixture
+    def valid_eta_line(self):
+        """Sample valid ETA parameter line."""
+        return "ETA   1    1.234E+00 2.345E-03 5.678E+01"
+        #       |     |    |         |         |
+        #       |     |    |         |         31-40: Energy (eV)
+        #       |     |    |         21-30: Uncertainty
+        #       |     |    11-20: Nu value
+        #       |     7: Flag
+        #       1-5: "ETA "
+
+    @pytest.fixture
+    def valid_eta_params(self):
+        """Sample valid ETA parameters."""
+        return EtaParameters(nu_value=1.234, nu_uncertainty=2.345e-3, energy=56.78, flag=VaryFlag.YES)
+
+    def test_parse_valid_line(self, valid_eta_line):
+        """Test parsing of valid ETA parameter line."""
+        # check col number for each char
+        for i, char in enumerate(valid_eta_line):
+            print(f"{i+1}: {char}")
+
+        params = EtaParameters.from_lines([valid_eta_line])
+        assert params.nu_value == pytest.approx(1.234)
+        assert params.nu_uncertainty == pytest.approx(2.345e-3)
+        assert params.energy == pytest.approx(56.78)
+        assert params.flag == VaryFlag.YES
+
+    def test_round_trip(self, valid_eta_params):
+        """Test round-trip parsing and formatting of ETA parameters."""
+        lines = valid_eta_params.to_lines()
+        assert len(lines) == 1
+        params = EtaParameters.from_lines(lines)
+        assert params == valid_eta_params
+
+    @pytest.mark.parametrize(
+        "invalid_line",
+        [
+            "",  # Empty line
+            "ETA   x    1.234E+00 2.345E-03 5.678E+01",  # Invalid flag
+            "ETA   1    invalid   2.345E-03 5.678E+01",  # Invalid nu value
+            "ETAX  1    1.234E+00 2.345E-03 5.678E+01",  # Wrong identifier
+        ],
+    )
+    def test_parse_invalid_lines(self, invalid_line):
+        """Test parsing of invalid ETA parameter lines."""
+        with pytest.raises(ValueError):
+            EtaParameters.from_lines([invalid_line])
+
+    def test_required_values(self):
+        """Test that required values must be provided."""
+        with pytest.raises(ValueError):
+            EtaParameters(
+                nu_value=None,  # Required
+                energy=56.78,
+            )
+
+    def test_energy_optional(self):
+        """Test that energy value is optional."""
+        line = "ETA   1    1.234E+00 2.345E-03"  # No energy value
+        params = EtaParameters.from_lines([line])
+        assert params.energy is None
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
This PR added the parser support for 11th card, misc parameters.

> EWM item: [8916](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8916)

