### PR TITLE
Caching for nuclear data from remote database

### DIFF
--- a/docs/development/migration_to_loguru.md
+++ b/docs/development/migration_to_loguru.md
@@ -1,0 +1,121 @@
+# Migrating to Loguru
+
+PLEIADES has migrated from Python's native logging to [Loguru](https://github.com/Delgan/loguru) to provide a better logging experience. This document provides guidance on how to use the new logging system.
+
+## Benefits of Loguru
+
+- Simpler API with sensible defaults
+- Pretty logging with colors in the terminal
+- Automatic rotation of log files
+- Support for structured logging
+- Better stack trace formatting
+- No need for complex configuration
+
+## Using the Logger in Your Code
+
+### Before (native logging)
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+# Log messages
+logger.debug("Debug message")
+logger.info("Info message")
+logger.warning("Warning message")
+logger.error("Error message")
+```
+
+### After (with Loguru)
+
+```python
+from pleiades.utils.logger import loguru_logger
+
+# Set the module name
+logger = loguru_logger.bind(name=__name__)
+
+# Log messages
+logger.debug("Debug message")
+logger.info("Info message")
+logger.warning("Warning message")
+logger.error("Error message")
+```
+
+### Replacing logging.basicConfig
+
+If you previously used `logging.basicConfig()`, you can replace it with our `configure_logger()` function:
+
+```python
+# Before
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+# After
+from pleiades.utils.logger import configure_logger
+configure_logger(console_level="INFO")
+```
+
+## Backward Compatibility
+
+For backward compatibility, we maintain the original `Logger` class which now wraps Loguru:
+
+```python
+from pleiades.utils.logger import Logger
+logger = Logger(name=__name__, level="DEBUG")
+
+logger.debug("Debug message")
+```
+
+## Advanced Usage
+
+### Custom Configuration
+
+You can customize the logger behavior:
+
+```python
+from pleiades.utils.logger import configure_logger
+
+configure_logger(
+    console_level="INFO",                         # Console output level
+    file_level="DEBUG",                           # File output level
+    log_file="my_custom_logfile.log",             # Custom log filename
+    rotation="1 day",                             # Rotate logs daily
+    retention="1 week",                           # Keep logs for 1 week
+    format_string="{time} | {message}"            # Custom format
+)
+```
+
+### Context Attributes
+
+Loguru supports adding context to log records:
+
+```python
+logger = loguru_logger.bind(component="nuclear", version="1.0")
+logger.info("Component initialized")  # Will include component and version in log
+```
+
+### Exception Logging
+
+Loguru provides enhanced exception logging:
+
+```python
+try:
+    1 / 0
+except Exception:
+    logger.exception("An error occurred")  # Will log the full traceback
+```
+
+### Programmatic Log Level Setting
+
+```python
+from pleiades.utils.logger import configure_logger
+
+# Set different levels for console and file
+configure_logger(console_level="WARNING", file_level="DEBUG")
+```
+
+## Default Log File Location
+
+By default, Loguru will create a log file named `pleiades_YYYYMMDD_HHMMSS.log` in the current working directory.
+
+You can change this by calling `configure_logger()` with a custom path.

--- a/notebook/tutorial/pleiades_endf_retrieval_caching.ipynb
+++ b/notebook/tutorial/pleiades_endf_retrieval_caching.ipynb
@@ -71,8 +71,8 @@
       "    Library: EndfLibrary.JENDL_5 (0 files)\n",
       "    Library: EndfLibrary.TENDL_2021 (0 files)\n",
       "    Library: EndfLibrary.JEFF_3_3 (0 files)\n",
-      "    Library: EndfLibrary.ENDF_B_VIII_1 (1 files)\n",
-      "    Library: EndfLibrary.ENDF_B_VIII_0 (2 files)\n",
+      "    Library: EndfLibrary.ENDF_B_VIII_1 (0 files)\n",
+      "    Library: EndfLibrary.ENDF_B_VIII_0 (0 files)\n",
       "    Library: EndfLibrary.CENDL_3_2 (0 files)\n"
      ]
     }
@@ -106,16 +106,16 @@
      "output_type": "stream",
      "text": [
       "Testing with isotope: U-238\n",
-      "Searching for mass.mas20 in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20')}\n",
+      "Searching for mass.mas20 in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info')}\n",
       "Checking file: neutrons.list\n",
-      "Checking file: isotopes.info\n",
       "Checking file: mass.mas20\n",
       "Found file: /Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20\n",
-      "Searching for isotopes.info in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20')}\n",
+      "Searching for isotopes.info in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info')}\n",
       "Checking file: neutrons.list\n",
+      "Checking file: mass.mas20\n",
       "Checking file: isotopes.info\n",
       "Found file: /Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info\n",
-      "Searching for neutrons.list in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20')}\n",
+      "Searching for neutrons.list in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info')}\n",
       "Checking file: neutrons.list\n",
       "Found file: /Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list\n",
       "Isotope details: IsotopeInfo class for: U-238\n"
@@ -140,8 +140,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pleiades.nuclear.manager:Using cached ENDF data from /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_0/n_9237_92-U-238.dat\n",
-      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.0.par\n"
+      "INFO:pleiades.nuclear.manager:Downloading ENDF data from https://www-nds.iaea.org/public/download-endf/ENDF-B-VIII.0/n/n_9237_92-U-238.zip\n"
      ]
     },
     {
@@ -149,10 +148,23 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "First download (should fetch from remote):\n",
+      "First download (should fetch from remote):\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.0.par\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Output file: endf_test/092-U-238.B-VIII.0.par\n",
-      "CPU times: user 25.9 ms, sys: 10.6 ms, total: 36.5 ms\n",
-      "Wall time: 39.2 ms\n"
+      "CPU times: user 106 ms, sys: 67.1 ms, total: 173 ms\n",
+      "Wall time: 2.06 s\n"
      ]
     }
    ],
@@ -236,8 +248,8 @@
       "\n",
       "Second download (should use cache):\n",
       "Output file: endf_test/092-U-238.B-VIII.0.par\n",
-      "CPU times: user 27.8 ms, sys: 8.88 ms, total: 36.7 ms\n",
-      "Wall time: 42 ms\n"
+      "CPU times: user 25.3 ms, sys: 8.78 ms, total: 34.1 ms\n",
+      "Wall time: 35.5 ms\n"
      ]
     }
    ],
@@ -264,8 +276,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pleiades.nuclear.manager:Using cached ENDF data from /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_1/n_092-U-238_9237.dat\n",
-      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.1.par\n"
+      "INFO:pleiades.nuclear.manager:Downloading ENDF data from https://www-nds.iaea.org/public/download-endf/ENDF-B-VIII.1/n/n_092-U-238_9237.zip\n"
      ]
     },
     {
@@ -273,12 +284,25 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Testing with ENDF-B-VIII.1 (different filename format):\n",
+      "Testing with ENDF-B-VIII.1 (different filename format):\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.1.par\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Output file: endf_test/092-U-238.B-VIII.1.par\n",
       "VIII.1 cache file path: /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_1/n_092-U-238_9237.dat\n",
       "VIII.1 exists in cache: True\n",
-      "CPU times: user 22.4 ms, sys: 6.76 ms, total: 29.2 ms\n",
-      "Wall time: 29.8 ms\n"
+      "CPU times: user 93.1 ms, sys: 55.4 ms, total: 148 ms\n",
+      "Wall time: 1.51 s\n"
      ]
     }
    ],
@@ -315,7 +339,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pleiades.nuclear.manager:Using cached ENDF data from /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_0/n_9228_92-U-235.dat\n"
+      "INFO:pleiades.nuclear.manager:Downloading ENDF data from https://www-nds.iaea.org/public/download-endf/ENDF-B-VIII.0/n/n_9228_92-U-235.zip\n"
      ]
     },
     {
@@ -339,8 +363,8 @@
      "output_type": "stream",
      "text": [
       "Output file: endf_test/092-U-235.B-VIII.0.par\n",
-      "CPU times: user 64.2 ms, sys: 25 ms, total: 89.2 ms\n",
-      "Wall time: 89.6 ms\n"
+      "CPU times: user 227 ms, sys: 189 ms, total: 416 ms\n",
+      "Wall time: 2.71 s\n"
      ]
     }
    ],

--- a/notebook/tutorial/pleiades_endf_retrieval_caching.ipynb
+++ b/notebook/tutorial/pleiades_endf_retrieval_caching.ipynb
@@ -4,7 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# ENDF Data Retrieval and Caching in PLEIADES"
+    "# ENDF Data Retrieval and Caching in PLEIADES\n",
+    "\n",
+    "This notebook demonstrates how to use the PLEIADES nuclear data management system to efficiently retrieve and cache ENDF (Evaluated Nuclear Data File) resonance data for nuclear calculations.\n",
+    "\n",
+    "## What You'll Learn\n",
+    "\n",
+    "1. How to configure the PLEIADES nuclear data cache\n",
+    "2. Two different methods for retrieving ENDF data:\n",
+    "   - **DIRECT Method**: Downloads complete ENDF files and extracts resonance data\n",
+    "   - **API Method**: Uses the IAEA EXFOR API to download only the resonance section\n",
+    "\n",
+    "## Benefits of Each Approach\n",
+    "\n",
+    "- **DIRECT Method**: \n",
+    "  - Gets the complete ENDF file (all sections)\n",
+    "  - Useful when you need the entire dataset\n",
+    "  - Higher storage requirements\n",
+    "\n",
+    "- **API Method**:\n",
+    "  - Downloads only the resonance data section\n",
+    "  - Faster and more efficient\n",
+    "  - Lower storage requirements\n",
+    "  - Ideal when you only need resonance parameters"
    ]
   },
   {
@@ -13,9 +35,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
+    "import time\n",
+    "import shutil\n",
     "from pathlib import Path\n",
-    "from pleiades.nuclear.manager import NuclearDataManager, DataSource, EndfLibrary\n",
+    "from pleiades.nuclear.manager import NuclearDataManager, EndfLibrary\n",
+    "from pleiades.nuclear.models import DataRetrievalMethod\n",
     "from pleiades.utils.config import get_config\n",
     "import logging\n",
     "\n",
@@ -33,12 +57,14 @@
      "output_type": "stream",
      "text": [
       "Cache directory: /Users/8cz/.pleiades/nuclear_data\n",
-      "Available data sources: {'IAEA': 'https://www-nds.iaea.org/public/download-endf', 'NNDC': 'https://www.nndc.bnl.gov/endf/b8.0/data'}\n",
-      "Output directory: /Users/8cz/github.com/PLEIADES/notebook/tutorial/endf_test\n"
+      "Available data sources: {'DIRECT': 'https://www-nds.iaea.org/public/download-endf', 'API': 'https://www-nds.iaea.org/exfor/servlet'}\n",
+      "Output directory: /Users/8cz/github.com/PLEIADES/notebook/tutorial/endf_test\n",
+      "Cache directory cleared.\n"
      ]
     }
    ],
    "source": [
+    "# Get configuration and show available settings\n",
     "config = get_config()\n",
     "print(f\"Cache directory: {config.nuclear_data_cache_dir}\")\n",
     "print(f\"Available data sources: {config.nuclear_data_sources}\")\n",
@@ -46,7 +72,22 @@
     "# Create output directory for parameter files\n",
     "output_dir = Path(\"./endf_test\")\n",
     "output_dir.mkdir(exist_ok=True)\n",
-    "print(f\"Output directory: {output_dir.absolute()}\")"
+    "print(f\"Output directory: {output_dir.absolute()}\")\n",
+    "\n",
+    "# Option to clear the cache (set to True to clear)\n",
+    "CLEAR_CACHE = True  # Change to True if you want to clear the cache\n",
+    "\n",
+    "if CLEAR_CACHE:\n",
+    "    user_input = input(\"This will delete all cached ENDF files. Are you sure? (yes/no): \")\n",
+    "    if user_input.lower() == \"yes\":\n",
+    "        # Remove all files in the cache directory\n",
+    "        if config.nuclear_data_cache_dir.exists():\n",
+    "            shutil.rmtree(config.nuclear_data_cache_dir)\n",
+    "            print(\"Cache directory cleared.\")\n",
+    "            # Recreate the empty directory\n",
+    "            config.nuclear_data_cache_dir.mkdir(parents=True, exist_ok=True)\n",
+    "    else:\n",
+    "        print(\"Cache clearing skipped. Note that notebook outputs may differ from descriptions due to existing cached files.\")"
    ]
   },
   {
@@ -60,14 +101,14 @@
      "text": [
       "Default ENDF library: EndfLibrary.ENDF_B_VIII_0\n",
       "Cache structure:\n",
-      "  Source: DataSource.NNDC\n",
+      "  Method: DataRetrievalMethod.DIRECT\n",
       "    Library: EndfLibrary.JENDL_5 (0 files)\n",
       "    Library: EndfLibrary.TENDL_2021 (0 files)\n",
       "    Library: EndfLibrary.JEFF_3_3 (0 files)\n",
       "    Library: EndfLibrary.ENDF_B_VIII_1 (0 files)\n",
       "    Library: EndfLibrary.ENDF_B_VIII_0 (0 files)\n",
       "    Library: EndfLibrary.CENDL_3_2 (0 files)\n",
-      "  Source: DataSource.IAEA\n",
+      "  Method: DataRetrievalMethod.API\n",
       "    Library: EndfLibrary.JENDL_5 (0 files)\n",
       "    Library: EndfLibrary.TENDL_2021 (0 files)\n",
       "    Library: EndfLibrary.JEFF_3_3 (0 files)\n",
@@ -78,6 +119,7 @@
     }
    ],
    "source": [
+    "# Initialize NuclearDataManager\n",
     "nuclear_manager = NuclearDataManager()\n",
     "print(f\"Default ENDF library: {nuclear_manager.default_library}\")\n",
     "\n",
@@ -85,15 +127,22 @@
     "cache_root = config.nuclear_data_cache_dir\n",
     "print(\"Cache structure:\")\n",
     "if cache_root.exists():\n",
-    "    for source in os.listdir(cache_root):\n",
-    "        source_dir = cache_root / source\n",
-    "        if source_dir.is_dir():\n",
-    "            print(f\"  Source: {source}\")\n",
-    "            for library in os.listdir(source_dir):\n",
-    "                library_dir = source_dir / library\n",
+    "    for method_dir in cache_root.iterdir():\n",
+    "        if method_dir.is_dir():\n",
+    "            print(f\"  Method: {method_dir.name}\")\n",
+    "            for library_dir in method_dir.iterdir():\n",
     "                if library_dir.is_dir():\n",
     "                    file_count = len(list(library_dir.glob(\"*.dat\")))\n",
-    "                    print(f\"    Library: {library} ({file_count} files)\")"
+    "                    print(f\"    Library: {library_dir.name} ({file_count} files)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Isotope Setup\n",
+    "\n",
+    "First, we'll load information about the U-238 isotope which will be used throughout this tutorial."
    ]
   },
   {
@@ -106,16 +155,16 @@
      "output_type": "stream",
      "text": [
       "Testing with isotope: U-238\n",
-      "Searching for mass.mas20 in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info')}\n",
-      "Checking file: neutrons.list\n",
+      "Searching for mass.mas20 in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info')}\n",
       "Checking file: mass.mas20\n",
       "Found file: /Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20\n",
-      "Searching for isotopes.info in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info')}\n",
-      "Checking file: neutrons.list\n",
+      "Searching for isotopes.info in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info')}\n",
       "Checking file: mass.mas20\n",
+      "Checking file: neutrons.list\n",
       "Checking file: isotopes.info\n",
       "Found file: /Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info\n",
-      "Searching for neutrons.list in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info')}\n",
+      "Searching for neutrons.list in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info')}\n",
+      "Checking file: mass.mas20\n",
       "Checking file: neutrons.list\n",
       "Found file: /Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list\n",
       "Isotope details: IsotopeInfo class for: U-238\n"
@@ -132,6 +181,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Method 1: DIRECT Download\n",
+    "\n",
+    "This method downloads the complete ENDF file and extracts only the resonance parameters.\n",
+    "- Downloads entire ENDF file (all sections)\n",
+    "- Extracts only the resonance parameter lines\n",
+    "- Stores the complete file in cache for future use"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
@@ -140,7 +201,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pleiades.nuclear.manager:Downloading ENDF data from https://www-nds.iaea.org/public/download-endf/ENDF-B-VIII.0/n/n_9237_92-U-238.zip\n"
+      "INFO:pleiades.nuclear.manager:Downloading complete ENDF data from https://www-nds.iaea.org/public/download-endf/ENDF-B-VIII.0/n/n_9237_92-U-238.zip\n",
+      "INFO:pleiades.nuclear.manager:This will download and cache the entire ENDF file (all sections)\n"
      ]
     },
     {
@@ -148,14 +210,16 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "First download (should fetch from remote):\n"
+      "DIRECT Method - First download (should fetch from remote):\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.0.par\n"
+      "INFO:pleiades.nuclear.manager:Extracting resonance parameters from complete ENDF file\n",
+      "INFO:pleiades.nuclear.manager:Resonance parameters extracted and written to endf_test/092-U-238.B-VIII.0.par\n",
+      "INFO:pleiades.nuclear.manager:Note: Complete ENDF file was downloaded and resonance data was extracted (DIRECT method)\n"
      ]
     },
     {
@@ -163,20 +227,20 @@
      "output_type": "stream",
      "text": [
       "Output file: endf_test/092-U-238.B-VIII.0.par\n",
-      "CPU times: user 106 ms, sys: 67.1 ms, total: 173 ms\n",
-      "Wall time: 2.06 s\n"
+      "CPU times: user 115 ms, sys: 63.9 ms, total: 179 ms\n",
+      "Wall time: 2.12 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "# Download and extract resonance file (first time should download)\n",
-    "print(\"\\nFirst download (should fetch from remote):\")\n",
+    "print(\"\\nDIRECT Method - First download (should fetch from remote):\")\n",
     "output_path = nuclear_manager.download_endf_resonance_file(\n",
     "    isotope=isotope_info,\n",
     "    library=EndfLibrary.ENDF_B_VIII_0,\n",
     "    output_dir=str(output_dir),\n",
-    "    source=DataSource.IAEA,\n",
+    "    method=DataRetrievalMethod.DIRECT,\n",
     "    use_cache=True\n",
     ")\n",
     "print(f\"Output file: {output_path}\")"
@@ -191,7 +255,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cache file path: /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_0/n_9237_92-U-238.dat\n",
+      "Cache file path: /Users/8cz/.pleiades/nuclear_data/DataRetrievalMethod.DIRECT/EndfLibrary.ENDF_B_VIII_0/n_9237_92-U-238.dat\n",
       "Exists in cache: True\n",
       "Cache file size: 15741.04 KB\n",
       "\n",
@@ -205,8 +269,9 @@
     }
    ],
    "source": [
+    "# Examine the cached file\n",
     "cache_file_path = nuclear_manager._get_cache_file_path(\n",
-    "      source=DataSource.IAEA,\n",
+    "      method=DataRetrievalMethod.DIRECT,\n",
     "      library=EndfLibrary.ENDF_B_VIII_0,\n",
     "      isotope=isotope_info,\n",
     "      mat=isotope_info.material_number\n",
@@ -237,8 +302,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pleiades.nuclear.manager:Using cached ENDF data from /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_0/n_9237_92-U-238.dat\n",
-      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.0.par\n"
+      "INFO:pleiades.nuclear.manager:Using cached ENDF data from /Users/8cz/.pleiades/nuclear_data/DataRetrievalMethod.DIRECT/EndfLibrary.ENDF_B_VIII_0/n_9237_92-U-238.dat\n",
+      "INFO:pleiades.nuclear.manager:Extracting resonance parameters from complete ENDF file\n",
+      "INFO:pleiades.nuclear.manager:Resonance parameters extracted and written to endf_test/092-U-238.B-VIII.0.par\n",
+      "INFO:pleiades.nuclear.manager:Note: Complete ENDF file was downloaded and resonance data was extracted (DIRECT method)\n"
      ]
     },
     {
@@ -246,25 +313,48 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Second download (should use cache):\n",
+      "DIRECT Method - Second download (should use cache):\n",
       "Output file: endf_test/092-U-238.B-VIII.0.par\n",
-      "CPU times: user 25.3 ms, sys: 8.78 ms, total: 34.1 ms\n",
-      "Wall time: 35.5 ms\n"
+      "Output file size: 655.75 KB (only resonance parameters)\n",
+      "Size difference: The resonance-only file is 4.17% of the full ENDF file size\n",
+      "CPU times: user 33.4 ms, sys: 12.3 ms, total: 45.7 ms\n",
+      "Wall time: 43 ms\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "\n",
-    "print(\"\\nSecond download (should use cache):\")\n",
+    "print(\"\\nDIRECT Method - Second download (should use cache):\")\n",
     "output_path2 = nuclear_manager.download_endf_resonance_file(\n",
     "    isotope=isotope_info,\n",
     "    library=EndfLibrary.ENDF_B_VIII_0,\n",
     "    output_dir=str(output_dir),\n",
-    "    source=DataSource.IAEA,\n",
+    "    method=DataRetrievalMethod.DIRECT,\n",
     "    use_cache=True\n",
     ")\n",
-    "print(f\"Output file: {output_path2}\")"
+    "print(f\"Output file: {output_path2}\")\n",
+    "\n",
+    "# Check output file size\n",
+    "output_size = output_path2.stat().st_size\n",
+    "print(f\"Output file size: {output_size / 1024:.2f} KB (only resonance parameters)\")\n",
+    "\n",
+    "# Compare with full ENDF file\n",
+    "full_file_size = cache_file_path.stat().st_size if cache_file_path.exists() else 0\n",
+    "if full_file_size > 0:\n",
+    "    print(f\"Size difference: The resonance-only file is {output_size/full_file_size*100:.2f}% of the full ENDF file size\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Method 2: API-Based Retrieval\n",
+    "\n",
+    "This method uses the IAEA EXFOR API to directly download only the resonance section of the ENDF file.\n",
+    "- Only downloads the neutron resonance section (much smaller file)\n",
+    "- More efficient when you only need resonance parameters\n",
+    "- Still supports caching for improved performance on repeated use"
    ]
   },
   {
@@ -273,61 +363,42 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:pleiades.nuclear.manager:Downloading ENDF data from https://www-nds.iaea.org/public/download-endf/ENDF-B-VIII.1/n/n_092-U-238_9237.zip\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "Testing with ENDF-B-VIII.1 (different filename format):\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.1.par\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Output file: endf_test/092-U-238.B-VIII.1.par\n",
-      "VIII.1 cache file path: /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_1/n_092-U-238_9237.dat\n",
-      "VIII.1 exists in cache: True\n",
-      "CPU times: user 93.1 ms, sys: 55.4 ms, total: 148 ms\n",
-      "Wall time: 1.51 s\n"
+      "API cache file path: /Users/8cz/.pleiades/nuclear_data/DataRetrievalMethod.API/EndfLibrary.ENDF_B_VIII_0/n_092-U-238_9237_resonance.dat\n",
+      "Exists in cache: False\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
-    "print(\"\\nTesting with ENDF-B-VIII.1 (different filename format):\")\n",
+    "# Examine the API cached file\n",
+    "api_cache_file_path = nuclear_manager._get_cache_file_path(\n",
+    "      method=DataRetrievalMethod.API,\n",
+    "      library=EndfLibrary.ENDF_B_VIII_0,\n",
+    "      isotope=isotope_info,\n",
+    "      mat=isotope_info.material_number\n",
+    "  )\n",
+    "print(f\"API cache file path: {api_cache_file_path}\")\n",
+    "print(f\"Exists in cache: {api_cache_file_path.exists()}\")\n",
     "\n",
-    "output_path3 = nuclear_manager.download_endf_resonance_file(\n",
-    "    isotope=isotope_info,\n",
-    "    library=EndfLibrary.ENDF_B_VIII_1,\n",
-    "    output_dir=str(output_dir),\n",
-    "    source=DataSource.IAEA,\n",
-    "    use_cache=True\n",
-    ")\n",
-    "print(f\"Output file: {output_path3}\")\n",
+    "if api_cache_file_path.exists():\n",
+    "    # Get file size\n",
+    "    file_size = api_cache_file_path.stat().st_size\n",
+    "    print(f\"API cache file size: {file_size / 1024:.2f} KB\")\n",
     "\n",
-    "# Check the cache file path for VIII.1\n",
-    "cache_file_path2 = nuclear_manager._get_cache_file_path(\n",
-    "    source=DataSource.IAEA,\n",
-    "    library=EndfLibrary.ENDF_B_VIII_1,\n",
-    "    isotope=isotope_info,\n",
-    "    mat=isotope_info.material_number\n",
-    ")\n",
-    "print(f\"VIII.1 cache file path: {cache_file_path2}\")\n",
-    "print(f\"VIII.1 exists in cache: {cache_file_path2.exists()}\")"
+    "    # Compare with DIRECT method cache size\n",
+    "    if cache_file_path.exists():\n",
+    "        direct_size = cache_file_path.stat().st_size\n",
+    "        print(f\"Size comparison: API cache is {file_size/direct_size*100:.2f}% the size of DIRECT cache\")\n",
+    "\n",
+    "    # Preview first few lines\n",
+    "    print(\"\\nFirst 5 lines of API cached file:\")\n",
+    "    with open(api_cache_file_path, 'r') as f:\n",
+    "        for i, line in enumerate(f):\n",
+    "            if i >= 5:\n",
+    "                break\n",
+    "            print(line.strip())"
    ]
   },
   {
@@ -339,7 +410,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pleiades.nuclear.manager:Downloading ENDF data from https://www-nds.iaea.org/public/download-endf/ENDF-B-VIII.0/n/n_9228_92-U-235.zip\n"
+      "INFO:pleiades.nuclear.manager:Searching for neutron resonance data for U-238 in ENDF/B-VIII.0 via IAEA EXFOR API\n",
+      "INFO:pleiades.nuclear.manager:Note: This will download ONLY the resonance section, not the complete ENDF file\n"
      ]
     },
     {
@@ -347,45 +419,63 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Testing with another isotope: U-235\n",
-      "Isotope details: IsotopeInfo class for: U-235\n"
+      "API Method - Second download (should use cache):\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-235.B-VIII.0.par\n"
+      "INFO:pleiades.nuclear.manager:Found neutron resonance data (SectID: 19173028) for U-238 in INDEN-Aug2023\n",
+      "INFO:pleiades.nuclear.manager:Downloaded neutron resonance data section for U-238\n",
+      "INFO:pleiades.nuclear.manager:Cached as: /Users/8cz/.pleiades/nuclear_data/DataRetrievalMethod.API/EndfLibrary.ENDF_B_VIII_0/n_092-U-238_9237_resonance.dat\n",
+      "INFO:pleiades.nuclear.manager:API method returned resonance data directly, no extraction needed\n",
+      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.0.par\n",
+      "INFO:pleiades.nuclear.manager:Note: Only resonance data was downloaded (API method)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Output file: endf_test/092-U-235.B-VIII.0.par\n",
-      "CPU times: user 227 ms, sys: 189 ms, total: 416 ms\n",
-      "Wall time: 2.71 s\n"
+      "Output file: endf_test/092-U-238.B-VIII.0.par\n",
+      "Output file comparison: Both API and DIRECT methods produce the same resonance-only output files\n",
+      "API output size: 278.60 KB\n",
+      "DIRECT output size: 655.75 KB\n",
+      "CPU times: user 18.8 ms, sys: 7.89 ms, total: 26.7 ms\n",
+      "Wall time: 1.58 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "\n",
-    "isotope_str2 = \"U-235\"\n",
-    "print(f\"\\nTesting with another isotope: {isotope_str2}\")\n",
-    "\n",
-    "isotope_info2 = nuclear_manager.isotope_manager.get_isotope_info(isotope_str2)\n",
-    "print(f\"Isotope details: {isotope_info2}\")\n",
-    "\n",
-    "# Download and extract resonance file\n",
-    "output_path4 = nuclear_manager.download_endf_resonance_file(\n",
-    "    isotope=isotope_info2,\n",
+    "# Second download using API method (should use cache)\n",
+    "print(\"\\nAPI Method - Second download (should use cache):\")\n",
+    "output_path_api2 = nuclear_manager.download_endf_resonance_file(\n",
+    "    isotope=isotope_info,\n",
     "    library=EndfLibrary.ENDF_B_VIII_0,\n",
     "    output_dir=str(output_dir),\n",
-    "    source=DataSource.IAEA,\n",
+    "    method=DataRetrievalMethod.API,\n",
     "    use_cache=True\n",
     ")\n",
-    "print(f\"Output file: {output_path4}\")"
+    "print(f\"Output file: {output_path_api2}\")\n",
+    "\n",
+    "# Check output file size\n",
+    "api_output_size = output_path_api2.stat().st_size if output_path_api2.exists() else 0\n",
+    "if api_output_size > 0 and output_size > 0:\n",
+    "    print(f\"Output file comparison: Both API and DIRECT methods produce the same resonance-only output files\")\n",
+    "    print(f\"API output size: {api_output_size / 1024:.2f} KB\")\n",
+    "    print(f\"DIRECT output size: {output_size / 1024:.2f} KB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Performance Comparison\n",
+    "\n",
+    "Let's compare the performance of both methods by downloading data for another isotope (U-235).\n",
+    "We'll measure the time taken for each method and examine the cache sizes."
    ]
   },
   {
@@ -397,42 +487,264 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
+      "Testing with another isotope: U-235\n",
+      "Isotope details: IsotopeInfo class for: U-235\n"
+     ]
+    }
+   ],
+   "source": [
+    "isotope_str2 = \"U-235\"\n",
+    "print(f\"\\nTesting with another isotope: {isotope_str2}\")\n",
+    "\n",
+    "isotope_info2 = nuclear_manager.isotope_manager.get_isotope_info(isotope_str2)\n",
+    "print(f\"Isotope details: {isotope_info2}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Downloading complete ENDF data from https://www-nds.iaea.org/public/download-endf/ENDF-B-VIII.0/n/n_9228_92-U-235.zip\n",
+      "INFO:pleiades.nuclear.manager:This will download and cache the entire ENDF file (all sections)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading U-235 data using DIRECT method...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Extracting resonance parameters from complete ENDF file\n",
+      "INFO:pleiades.nuclear.manager:Resonance parameters extracted and written to endf_test/092-U-235.B-VIII.0.par\n",
+      "INFO:pleiades.nuclear.manager:Note: Complete ENDF file was downloaded and resonance data was extracted (DIRECT method)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DIRECT method time: 2.76 seconds\n",
+      "Output file: endf_test/092-U-235.B-VIII.0.par\n",
+      "CPU times: user 219 ms, sys: 177 ms, total: 396 ms\n",
+      "Wall time: 2.76 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Download U-235 data using DIRECT method\n",
+    "print(\"Downloading U-235 data using DIRECT method...\")\n",
+    "start_time = time.time()\n",
+    "output_direct_u235 = nuclear_manager.download_endf_resonance_file(\n",
+    "    isotope=isotope_info2,\n",
+    "    library=EndfLibrary.ENDF_B_VIII_0,\n",
+    "    output_dir=str(output_dir),\n",
+    "    method=DataRetrievalMethod.DIRECT,\n",
+    "    use_cache=True\n",
+    ")\n",
+    "direct_time = time.time() - start_time\n",
+    "print(f\"DIRECT method time: {direct_time:.2f} seconds\")\n",
+    "print(f\"Output file: {output_direct_u235}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Searching for neutron resonance data for U-235 in ENDF/B-VIII.0 via IAEA EXFOR API\n",
+      "INFO:pleiades.nuclear.manager:Note: This will download ONLY the resonance section, not the complete ENDF file\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading U-235 data using API method...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Found neutron resonance data (SectID: 19172584) for U-235 in INDEN-Aug2023\n",
+      "INFO:pleiades.nuclear.manager:Downloaded neutron resonance data section for U-235\n",
+      "INFO:pleiades.nuclear.manager:Cached as: /Users/8cz/.pleiades/nuclear_data/DataRetrievalMethod.API/EndfLibrary.ENDF_B_VIII_0/n_092-U-235_9228_resonance.dat\n",
+      "INFO:pleiades.nuclear.manager:API method returned resonance data directly, no extraction needed\n",
+      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-235.B-VIII.0.par\n",
+      "INFO:pleiades.nuclear.manager:Note: Only resonance data was downloaded (API method)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "API method time: 1.76 seconds\n",
+      "Output file: endf_test/092-U-235.B-VIII.0.par\n",
+      "\n",
+      "Performance comparison:\n",
+      "DIRECT method: 2.76 seconds\n",
+      "API method: 1.76 seconds\n",
+      "API method was 1.57x faster\n",
+      "CPU times: user 21.6 ms, sys: 8.39 ms, total: 30 ms\n",
+      "Wall time: 1.76 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Download U-235 data using API method\n",
+    "print(\"Downloading U-235 data using API method...\")\n",
+    "start_time = time.time()\n",
+    "output_api_u235 = nuclear_manager.download_endf_resonance_file(\n",
+    "    isotope=isotope_info2,\n",
+    "    library=EndfLibrary.ENDF_B_VIII_0,\n",
+    "    output_dir=str(output_dir),\n",
+    "    method=DataRetrievalMethod.API,\n",
+    "    use_cache=True\n",
+    ")\n",
+    "api_time = time.time() - start_time\n",
+    "print(f\"API method time: {api_time:.2f} seconds\")\n",
+    "print(f\"Output file: {output_api_u235}\")\n",
+    "\n",
+    "# Compare times\n",
+    "if direct_time > 0 and api_time > 0:\n",
+    "    print(f\"\\nPerformance comparison:\")\n",
+    "    print(f\"DIRECT method: {direct_time:.2f} seconds\")\n",
+    "    print(f\"API method: {api_time:.2f} seconds\")\n",
+    "    \n",
+    "    if direct_time > api_time:\n",
+    "        print(f\"API method was {direct_time/api_time:.2f}x faster\")\n",
+    "    else:\n",
+    "        print(f\"DIRECT method was {api_time/direct_time:.2f}x faster\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cache Structure Summary\n",
+    "\n",
+    "Let's examine the cache directory structure to see how files are organized and how the two methods compare in terms of storage requirements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Cache content summary with filename patterns:\n",
       "\n",
-      "Source: DataSource.NNDC\n",
-      "\n",
-      "Source: DataSource.IAEA\n",
-      "  Library: EndfLibrary.ENDF_B_VIII_1\n",
-      "    - n_092-U-238_9237.dat (14016.15 KB)\n",
-      "      Pattern: ELEMENT_FIRST (zero-padded Z)\n",
+      "Method: DataRetrievalMethod.DIRECT\n",
       "  Library: EndfLibrary.ENDF_B_VIII_0\n",
+      "  Total size: 54604.15 KB\n",
       "    - n_9228_92-U-235.dat (38863.12 KB)\n",
       "      Pattern: MAT_FIRST (non-zero-padded Z)\n",
       "    - n_9237_92-U-238.dat (15741.04 KB)\n",
-      "      Pattern: MAT_FIRST (non-zero-padded Z)\n"
+      "      Pattern: MAT_FIRST (non-zero-padded Z)\n",
+      "  Total DataRetrievalMethod.DIRECT cache size: 53.32 MB\n",
+      "\n",
+      "Method: DataRetrievalMethod.API\n",
+      "  Library: EndfLibrary.ENDF_B_VIII_0\n",
+      "  Total size: 539.63 KB\n",
+      "    - n_092-U-235_9228_resonance.dat (261.04 KB)\n",
+      "      Pattern: ELEMENT_FIRST (zero-padded Z)\n",
+      "    - n_092-U-238_9237_resonance.dat (278.60 KB)\n",
+      "      Pattern: ELEMENT_FIRST (zero-padded Z)\n",
+      "  Total DataRetrievalMethod.API cache size: 0.53 MB\n"
      ]
     }
    ],
    "source": [
     "print(\"Cache content summary with filename patterns:\")\n",
     "cache_root = config.nuclear_data_cache_dir\n",
+    "total_direct_size = 0\n",
+    "total_api_size = 0\n",
+    "\n",
     "if cache_root.exists():\n",
-    "    for source_dir in cache_root.iterdir():\n",
-    "        if source_dir.is_dir():\n",
-    "            print(f\"\\nSource: {source_dir.name}\")\n",
-    "            for library_dir in source_dir.iterdir():\n",
+    "    for method_dir in cache_root.iterdir():\n",
+    "        if method_dir.is_dir():\n",
+    "            method_size = 0\n",
+    "            print(f\"\\nMethod: {method_dir.name}\")\n",
+    "            for library_dir in method_dir.iterdir():\n",
     "                if library_dir.is_dir():\n",
     "                    files = list(library_dir.glob(\"*.dat\"))\n",
+    "                    lib_size = sum(f.stat().st_size for f in files)\n",
+    "                    method_size += lib_size\n",
+    "                    \n",
     "                    if files:\n",
     "                        print(f\"  Library: {library_dir.name}\")\n",
+    "                        print(f\"  Total size: {lib_size / 1024:.2f} KB\")\n",
     "                        for file in files:\n",
     "                            file_size = file.stat().st_size\n",
     "                            print(f\"    - {file.name} ({file_size / 1024:.2f} KB)\")\n",
-    "                            # Highlight the pattern type\n",
+    "                            \n",
+    "                            # Check filename pattern\n",
     "                            if \"_\" in file.name and file.name.split(\"_\")[1].isdigit():\n",
     "                                print(f\"      Pattern: MAT_FIRST (non-zero-padded Z)\")\n",
     "                            else:\n",
-    "                                print(f\"      Pattern: ELEMENT_FIRST (zero-padded Z)\")"
+    "                                print(f\"      Pattern: ELEMENT_FIRST (zero-padded Z)\")\n",
+    "            \n",
+    "            # Add to method totals\n",
+    "            if method_dir.name == 'DIRECT':\n",
+    "                total_direct_size = method_size\n",
+    "            elif method_dir.name == 'API':\n",
+    "                total_api_size = method_size\n",
+    "            \n",
+    "            print(f\"  Total {method_dir.name} cache size: {method_size / (1024*1024):.2f} MB\")\n",
+    "    \n",
+    "    # Overall comparison\n",
+    "    if total_direct_size > 0 and total_api_size > 0:\n",
+    "        print(f\"\\nOverall storage comparison:\")\n",
+    "        print(f\"Total DIRECT cache: {total_direct_size / (1024*1024):.2f} MB\")\n",
+    "        print(f\"Total API cache: {total_api_size / (1024*1024):.2f} MB\")\n",
+    "        print(f\"API method uses {total_api_size/total_direct_size*100:.2f}% of the DIRECT method's storage\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion: Choosing the Right Method\n",
+    "\n",
+    "Both methods have their advantages:\n",
+    "\n",
+    "- **DIRECT Method**:\n",
+    "  - Downloads the complete ENDF file\n",
+    "  - Good when you need access to other sections beyond resonance data\n",
+    "  - Higher storage requirements\n",
+    "  - May take longer for initial download\n",
+    "\n",
+    "- **API Method**:\n",
+    "  - Downloads only the resonance section\n",
+    "  - Faster downloads and lower storage requirements\n",
+    "  - Ideal when you only need resonance parameters for calculations\n",
+    "  - Particularly useful for large-scale processing of many isotopes\n",
+    "\n",
+    "### Usage Guidelines:\n",
+    "- Use **DIRECT** when you need complete ENDF files or multiple sections\n",
+    "- Use **API** when you only need resonance parameters and want to optimize performance and storage\n",
+    "\n",
+    "Both methods benefit from caching, which significantly speeds up subsequent retrievals."
    ]
   },
   {

--- a/notebook/tutorial/pleiades_endf_retrieval_caching.ipynb
+++ b/notebook/tutorial/pleiades_endf_retrieval_caching.ipynb
@@ -1,0 +1,443 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ENDF Data Retrieval and Caching in PLEIADES"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "from pleiades.nuclear.manager import NuclearDataManager, DataSource, EndfLibrary\n",
+    "from pleiades.utils.config import get_config\n",
+    "import logging\n",
+    "\n",
+    "# Configure logging to see debug information\n",
+    "logging.basicConfig(level=logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cache directory: /Users/8cz/.pleiades/nuclear_data\n",
+      "Available data sources: {'IAEA': 'https://www-nds.iaea.org/public/download-endf', 'NNDC': 'https://www.nndc.bnl.gov/endf/b8.0/data'}\n",
+      "Output directory: /Users/8cz/github.com/PLEIADES/notebook/tutorial/endf_test\n"
+     ]
+    }
+   ],
+   "source": [
+    "config = get_config()\n",
+    "print(f\"Cache directory: {config.nuclear_data_cache_dir}\")\n",
+    "print(f\"Available data sources: {config.nuclear_data_sources}\")\n",
+    "\n",
+    "# Create output directory for parameter files\n",
+    "output_dir = Path(\"./endf_test\")\n",
+    "output_dir.mkdir(exist_ok=True)\n",
+    "print(f\"Output directory: {output_dir.absolute()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default ENDF library: EndfLibrary.ENDF_B_VIII_0\n",
+      "Cache structure:\n",
+      "  Source: DataSource.NNDC\n",
+      "    Library: EndfLibrary.JENDL_5 (0 files)\n",
+      "    Library: EndfLibrary.TENDL_2021 (0 files)\n",
+      "    Library: EndfLibrary.JEFF_3_3 (0 files)\n",
+      "    Library: EndfLibrary.ENDF_B_VIII_1 (0 files)\n",
+      "    Library: EndfLibrary.ENDF_B_VIII_0 (0 files)\n",
+      "    Library: EndfLibrary.CENDL_3_2 (0 files)\n",
+      "  Source: DataSource.IAEA\n",
+      "    Library: EndfLibrary.JENDL_5 (0 files)\n",
+      "    Library: EndfLibrary.TENDL_2021 (0 files)\n",
+      "    Library: EndfLibrary.JEFF_3_3 (0 files)\n",
+      "    Library: EndfLibrary.ENDF_B_VIII_1 (1 files)\n",
+      "    Library: EndfLibrary.ENDF_B_VIII_0 (2 files)\n",
+      "    Library: EndfLibrary.CENDL_3_2 (0 files)\n"
+     ]
+    }
+   ],
+   "source": [
+    "nuclear_manager = NuclearDataManager()\n",
+    "print(f\"Default ENDF library: {nuclear_manager.default_library}\")\n",
+    "\n",
+    "# List cache directories\n",
+    "cache_root = config.nuclear_data_cache_dir\n",
+    "print(\"Cache structure:\")\n",
+    "if cache_root.exists():\n",
+    "    for source in os.listdir(cache_root):\n",
+    "        source_dir = cache_root / source\n",
+    "        if source_dir.is_dir():\n",
+    "            print(f\"  Source: {source}\")\n",
+    "            for library in os.listdir(source_dir):\n",
+    "                library_dir = source_dir / library\n",
+    "                if library_dir.is_dir():\n",
+    "                    file_count = len(list(library_dir.glob(\"*.dat\")))\n",
+    "                    print(f\"    Library: {library} ({file_count} files)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Testing with isotope: U-238\n",
+      "Searching for mass.mas20 in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20')}\n",
+      "Checking file: neutrons.list\n",
+      "Checking file: isotopes.info\n",
+      "Checking file: mass.mas20\n",
+      "Found file: /Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20\n",
+      "Searching for isotopes.info in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20')}\n",
+      "Checking file: neutrons.list\n",
+      "Checking file: isotopes.info\n",
+      "Found file: /Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info\n",
+      "Searching for neutrons.list in cached files for FileCategory.ISOTOPES: {PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/isotopes.info'), PosixPath('/Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/mass.mas20')}\n",
+      "Checking file: neutrons.list\n",
+      "Found file: /Users/8cz/github.com/PLEIADES/src/pleiades/nuclear/isotopes/files/neutrons.list\n",
+      "Isotope details: IsotopeInfo class for: U-238\n"
+     ]
+    }
+   ],
+   "source": [
+    "isotope_str = \"U-238\"  # Test with U-238\n",
+    "print(f\"Testing with isotope: {isotope_str}\")\n",
+    "\n",
+    "# Get isotope info\n",
+    "isotope_info = nuclear_manager.isotope_manager.get_isotope_info(isotope_str)\n",
+    "print(f\"Isotope details: {isotope_info}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Using cached ENDF data from /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_0/n_9237_92-U-238.dat\n",
+      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.0.par\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "First download (should fetch from remote):\n",
+      "Output file: endf_test/092-U-238.B-VIII.0.par\n",
+      "CPU times: user 25.9 ms, sys: 10.6 ms, total: 36.5 ms\n",
+      "Wall time: 39.2 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Download and extract resonance file (first time should download)\n",
+    "print(\"\\nFirst download (should fetch from remote):\")\n",
+    "output_path = nuclear_manager.download_endf_resonance_file(\n",
+    "    isotope=isotope_info,\n",
+    "    library=EndfLibrary.ENDF_B_VIII_0,\n",
+    "    output_dir=str(output_dir),\n",
+    "    source=DataSource.IAEA,\n",
+    "    use_cache=True\n",
+    ")\n",
+    "print(f\"Output file: {output_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cache file path: /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_0/n_9237_92-U-238.dat\n",
+      "Exists in cache: True\n",
+      "Cache file size: 15741.04 KB\n",
+      "\n",
+      "First 5 lines of cached file:\n",
+      "Retrieved by E4-util: 2018/02/07,18:09:12                            1 0  0    0\n",
+      "9.223800+4 2.360058+2          1          1          0          19237 1451    1\n",
+      "0.000000+0 0.000000+0          0          0          0          69237 1451    2\n",
+      "1.000000+0 3.000000+7          0          0         10          89237 1451    3\n",
+      "0.000000+0 0.000000+0          0          0        566        2469237 1451    4\n"
+     ]
+    }
+   ],
+   "source": [
+    "cache_file_path = nuclear_manager._get_cache_file_path(\n",
+    "      source=DataSource.IAEA,\n",
+    "      library=EndfLibrary.ENDF_B_VIII_0,\n",
+    "      isotope=isotope_info,\n",
+    "      mat=isotope_info.material_number\n",
+    "  )\n",
+    "print(f\"Cache file path: {cache_file_path}\")\n",
+    "print(f\"Exists in cache: {cache_file_path.exists()}\")\n",
+    "\n",
+    "if cache_file_path.exists():\n",
+    "    # Get file size\n",
+    "    file_size = cache_file_path.stat().st_size\n",
+    "    print(f\"Cache file size: {file_size / 1024:.2f} KB\")\n",
+    "\n",
+    "    # Preview first few lines\n",
+    "    print(\"\\nFirst 5 lines of cached file:\")\n",
+    "    with open(cache_file_path, 'r') as f:\n",
+    "        for i, line in enumerate(f):\n",
+    "            if i >= 5:\n",
+    "                break\n",
+    "            print(line.strip())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Using cached ENDF data from /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_0/n_9237_92-U-238.dat\n",
+      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.0.par\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Second download (should use cache):\n",
+      "Output file: endf_test/092-U-238.B-VIII.0.par\n",
+      "CPU times: user 27.8 ms, sys: 8.88 ms, total: 36.7 ms\n",
+      "Wall time: 42 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "print(\"\\nSecond download (should use cache):\")\n",
+    "output_path2 = nuclear_manager.download_endf_resonance_file(\n",
+    "    isotope=isotope_info,\n",
+    "    library=EndfLibrary.ENDF_B_VIII_0,\n",
+    "    output_dir=str(output_dir),\n",
+    "    source=DataSource.IAEA,\n",
+    "    use_cache=True\n",
+    ")\n",
+    "print(f\"Output file: {output_path2}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Using cached ENDF data from /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_1/n_092-U-238_9237.dat\n",
+      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-238.B-VIII.1.par\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Testing with ENDF-B-VIII.1 (different filename format):\n",
+      "Output file: endf_test/092-U-238.B-VIII.1.par\n",
+      "VIII.1 cache file path: /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_1/n_092-U-238_9237.dat\n",
+      "VIII.1 exists in cache: True\n",
+      "CPU times: user 22.4 ms, sys: 6.76 ms, total: 29.2 ms\n",
+      "Wall time: 29.8 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "print(\"\\nTesting with ENDF-B-VIII.1 (different filename format):\")\n",
+    "\n",
+    "output_path3 = nuclear_manager.download_endf_resonance_file(\n",
+    "    isotope=isotope_info,\n",
+    "    library=EndfLibrary.ENDF_B_VIII_1,\n",
+    "    output_dir=str(output_dir),\n",
+    "    source=DataSource.IAEA,\n",
+    "    use_cache=True\n",
+    ")\n",
+    "print(f\"Output file: {output_path3}\")\n",
+    "\n",
+    "# Check the cache file path for VIII.1\n",
+    "cache_file_path2 = nuclear_manager._get_cache_file_path(\n",
+    "    source=DataSource.IAEA,\n",
+    "    library=EndfLibrary.ENDF_B_VIII_1,\n",
+    "    isotope=isotope_info,\n",
+    "    mat=isotope_info.material_number\n",
+    ")\n",
+    "print(f\"VIII.1 cache file path: {cache_file_path2}\")\n",
+    "print(f\"VIII.1 exists in cache: {cache_file_path2.exists()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Using cached ENDF data from /Users/8cz/.pleiades/nuclear_data/DataSource.IAEA/EndfLibrary.ENDF_B_VIII_0/n_9228_92-U-235.dat\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Testing with another isotope: U-235\n",
+      "Isotope details: IsotopeInfo class for: U-235\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pleiades.nuclear.manager:Resonance parameters written to endf_test/092-U-235.B-VIII.0.par\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output file: endf_test/092-U-235.B-VIII.0.par\n",
+      "CPU times: user 64.2 ms, sys: 25 ms, total: 89.2 ms\n",
+      "Wall time: 89.6 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "isotope_str2 = \"U-235\"\n",
+    "print(f\"\\nTesting with another isotope: {isotope_str2}\")\n",
+    "\n",
+    "isotope_info2 = nuclear_manager.isotope_manager.get_isotope_info(isotope_str2)\n",
+    "print(f\"Isotope details: {isotope_info2}\")\n",
+    "\n",
+    "# Download and extract resonance file\n",
+    "output_path4 = nuclear_manager.download_endf_resonance_file(\n",
+    "    isotope=isotope_info2,\n",
+    "    library=EndfLibrary.ENDF_B_VIII_0,\n",
+    "    output_dir=str(output_dir),\n",
+    "    source=DataSource.IAEA,\n",
+    "    use_cache=True\n",
+    ")\n",
+    "print(f\"Output file: {output_path4}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cache content summary with filename patterns:\n",
+      "\n",
+      "Source: DataSource.NNDC\n",
+      "\n",
+      "Source: DataSource.IAEA\n",
+      "  Library: EndfLibrary.ENDF_B_VIII_1\n",
+      "    - n_092-U-238_9237.dat (14016.15 KB)\n",
+      "      Pattern: ELEMENT_FIRST (zero-padded Z)\n",
+      "  Library: EndfLibrary.ENDF_B_VIII_0\n",
+      "    - n_9228_92-U-235.dat (38863.12 KB)\n",
+      "      Pattern: MAT_FIRST (non-zero-padded Z)\n",
+      "    - n_9237_92-U-238.dat (15741.04 KB)\n",
+      "      Pattern: MAT_FIRST (non-zero-padded Z)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Cache content summary with filename patterns:\")\n",
+    "cache_root = config.nuclear_data_cache_dir\n",
+    "if cache_root.exists():\n",
+    "    for source_dir in cache_root.iterdir():\n",
+    "        if source_dir.is_dir():\n",
+    "            print(f\"\\nSource: {source_dir.name}\")\n",
+    "            for library_dir in source_dir.iterdir():\n",
+    "                if library_dir.is_dir():\n",
+    "                    files = list(library_dir.glob(\"*.dat\"))\n",
+    "                    if files:\n",
+    "                        print(f\"  Library: {library_dir.name}\")\n",
+    "                        for file in files:\n",
+    "                            file_size = file.stat().st_size\n",
+    "                            print(f\"    - {file.name} ({file_size / 1024:.2f} KB)\")\n",
+    "                            # Highlight the pattern type\n",
+    "                            if \"_\" in file.name and file.name.split(\"_\")[1].isdigit():\n",
+    "                                print(f\"      Pattern: MAT_FIRST (non-zero-padded Z)\")\n",
+    "                            else:\n",
+    "                                print(f\"      Pattern: ELEMENT_FIRST (zero-padded Z)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "default",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pixi.lock
+++ b/pixi.lock
@@ -195,6 +195,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.7-h4bc477f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/loguru-0.7.2-py311h38be061_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
@@ -542,6 +543,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-20.1.2-hdb05f8b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-18-18.1.8-hc4b4ae8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-18.1.8-hc4b4ae8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/loguru-0.7.2-py311h267d04e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
@@ -878,6 +880,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.13.7-h4bc477f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/loguru-0.7.2-py313h78bf25f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.2-py313h8060acc_1.conda
@@ -1153,6 +1156,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.13.7-h52572c6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-20.1.2-hdb05f8b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/loguru-0.7.2-py312h81bd7bf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.2-py312h998013c_1.conda
@@ -1724,7 +1728,8 @@ packages:
   constrains:
   - tinycss >=1.1.0,<1.5
   license: Apache-2.0 AND MIT
-  purls: []
+  purls:
+  - pkg:pypi/bleach?source=hash-mapping
   size: 141405
   timestamp: 1737382993425
 - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
@@ -3239,7 +3244,8 @@ packages:
   - certifi
   license: BSD-3-Clause
   license_family: BSD
-  purls: []
+  purls:
+  - pkg:pypi/httpcore?source=hash-mapping
   size: 48959
   timestamp: 1731707562362
 - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
@@ -5459,6 +5465,56 @@ packages:
   purls: []
   size: 23610271
   timestamp: 1737837584505
+- conda: https://conda.anaconda.org/conda-forge/linux-64/loguru-0.7.2-py311h38be061_2.conda
+  sha256: 3c1ea0a9c37fac760c94f167899b4c15ffc967cbeb83f6ed61d49c9974fab46c
+  md5: 733b481d20ff260a34f2b0003ff4fbb3
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/loguru?source=hash-mapping
+  size: 126239
+  timestamp: 1725349863378
+- conda: https://conda.anaconda.org/conda-forge/linux-64/loguru-0.7.2-py313h78bf25f_2.conda
+  sha256: c667bca9b58c66953c8c3b39b9e00c8192316d8ad19bfec5f0b488cd2afa3061
+  md5: a2d253474bc86a3e7aa382c63d573357
+  depends:
+  - python >=3.13.0rc1,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/loguru?source=hash-mapping
+  size: 126928
+  timestamp: 1725349841791
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/loguru-0.7.2-py311h267d04e_2.conda
+  sha256: dd218c3908ae4eb16c5acb977570baf0c56f74af02daca6a151c33ea182b18df
+  md5: 85ca4ac94b7c12fc61fa4b7cbb5f5b14
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/loguru?source=hash-mapping
+  size: 126364
+  timestamp: 1725350146667
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/loguru-0.7.2-py312h81bd7bf_2.conda
+  sha256: 09c51d5b2c07232c9fa84bdd6f2c6f98536d3a2568ba427ab1d45b634bd30bf4
+  md5: c4bf17db944569f3b0e2e100c91c54e2
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/loguru?source=hash-mapping
+  size: 123434
+  timestamp: 1725349952242
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
   md5: 9de5350a85c4a20c685259b889aa6393
@@ -6746,8 +6802,8 @@ packages:
   timestamp: 1742485085457
 - pypi: .
   name: pleiades
-  version: 0.2.0.dev333+d202504172044
-  sha256: 363c24039407da8685c811c66f04dab2b038fe7adc57ffb06a3e3738980b8826
+  version: 0.2.0.dev337+d202504180111
+  sha256: e1499a48460b87a639d4eefcd9902da26febc62d534d69ebfa02608fe5acf5b1
   requires_dist:
   - numpy
   - scipy
@@ -6756,6 +6812,7 @@ packages:
   - jupyterlab
   - pyyaml
   - pydantic
+  - loguru
   - nova-galaxy>=0.7.4,<0.8
   requires_python: '>=3.10,<4.0'
   editable: true

--- a/pixi.lock
+++ b/pixi.lock
@@ -6746,8 +6746,8 @@ packages:
   timestamp: 1742485085457
 - pypi: .
   name: pleiades
-  version: 0.2.0.dev327+d202504151742
-  sha256: 3f8e9362cebf2d68fddd29a7e194bd6ed675d65904400c30359922a5afdcd457
+  version: 0.2.0.dev333+d202504172044
+  sha256: 363c24039407da8685c811c66f04dab2b038fe7adc57ffb06a3e3738980b8826
   requires_dist:
   - numpy
   - scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,14 +147,15 @@ clean-conda = { cmd = "sh -c \"find conda.recipe/* ! -name 'meta.yaml' -exec rm 
 build-docs = { cmd = "sphinx-build -b html docs docs/_build", description = "Build the documentation" }
 clean-docs = { cmd = "rm -rf docs/_build", description = "Clean the documentation build artifacts" }
 # Testing tasks
-test = { cmd = "pytest", description = "Run the tests" }  # pytest config above takes care of the arguments
+test = { cmd = "pytest tests --cov-branch --cov=src/pleiades --cov-report=term --cov-report=xml", description = "Run the tests" }  # pytest config above takes care of the arguments
+clean-test = { cmd = "rm -rf .pytest_cache .coverage coverage.xml", description = "Clean the test cache" }
 # Development tasks
 lint = { cmd = "ruff check .", description = "Run linting checks" }
 format = { cmd = "ruff format .", description = "Format code with ruff" }
 pre-commit-install = { cmd = "pre-commit install", description = "Install pre-commit hooks" }
 pre-commit-run = { cmd = "pre-commit run --all-files", description = "Run pre-commit on all files" }
 # Clean all
-clean-all = { description = "Clean all build artifacts", depends-on = ["clean-pypi", "clean-conda", "clean-docs"] }
+clean-all = { description = "Clean all build artifacts", depends-on = ["clean-pypi", "clean-conda", "clean-docs", "clean-test"] }
 
 [tool.pixi.feature.test.dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "jupyterlab",
     "pyyaml",
     "pydantic",
+    "loguru",
     "nova-galaxy>=0.7.4,<0.8",
 ]
 
@@ -130,6 +131,7 @@ matplotlib = ">=3.10.1,<4"
 jupyterlab = ">=4.4.0,<5"
 pyyaml = ">=6.0.2,<7"
 pydantic = ">=2.11.2,<3"
+loguru = ">=0.7.2,<0.8"
 
 [tool.pixi.tasks]
 # PyPi packaging tasks

--- a/src/pleiades/__init__.py
+++ b/src/pleiades/__init__.py
@@ -1,0 +1,35 @@
+"""
+PLEIADES - Python Libraries Extensions for Isotopic Analysis via Detailed Examination of SAMMY.
+
+A Python package for analyzing neutron resonance data using SAMMY.
+"""
+
+import argparse
+
+from pleiades.utils.logger import configure_logger, loguru_logger
+
+# Import _version if available
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "0.0.0.dev0"
+
+# Export main components
+__all__ = ["loguru_logger", "configure_logger"]
+
+
+def main():
+    """Main entry point for the application."""
+    parser = argparse.ArgumentParser(
+        description="PLEIADES - Python Libraries Extensions for Isotopic Analysis via Detailed Examination of SAMMY"
+    )
+    parser.add_argument("--version", action="store_true", help="Print version information")
+    args = parser.parse_args()
+
+    if args.version:
+        print(f"PLEIADES version {__version__}")
+    else:
+        print(
+            f"PLEIADES {__version__} - Python Libraries Extensions for Isotopic Analysis via Detailed Examination of SAMMY"
+        )
+        print("Run with --help for available options")

--- a/src/pleiades/nuclear/manager.py
+++ b/src/pleiades/nuclear/manager.py
@@ -5,19 +5,20 @@ import io
 import logging
 import zipfile
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import requests
 
 from pleiades.nuclear.isotopes.manager import IsotopeManager
 from pleiades.nuclear.isotopes.models import IsotopeInfo
-from pleiades.nuclear.models import IsotopeParameters
+from pleiades.nuclear.models import DataSource, EndfLibrary, IsotopeParameters
+from pleiades.utils.config import get_config
 
 logger = logging.getLogger(__name__)
 
 
 class NuclearDataManager:
-    # TODO: Setup nuclear/data/ directory to save and cache ENDF/JENDL/JEFF data files
+    """Manager for nuclear data files and caching."""
 
     def __init__(self, isotope_manager: Optional[IsotopeManager] = None):
         """
@@ -27,6 +28,52 @@ class NuclearDataManager:
             isotope_manager: Optional instance of IsotopeManager. If not provided, a new instance will be created.
         """
         self.isotope_manager = isotope_manager or IsotopeManager()
+        # Initialize cache directory
+        self._initialize_cache()
+        # Default ENDF library - pinned to VIII.0
+        self.default_library = EndfLibrary.ENDF_B_VIII_0
+
+    def _initialize_cache(self) -> None:
+        """Initialize the cache directory structure."""
+        config = get_config()
+        # Ensure cache directories exist for each data source and library
+        for source in DataSource:
+            for library in EndfLibrary:
+                cache_dir = self._get_cache_dir(source, library)
+                cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_cache_dir(self, source: DataSource, library: EndfLibrary) -> Path:
+        """
+        Get the cache directory for a specific data source and library.
+
+        Args:
+            source: The data source (IAEA, NNDC)
+            library: The ENDF library version
+
+        Returns:
+            Path to the cache directory
+        """
+        config = get_config()
+        return config.nuclear_data_cache_dir / source / library
+
+    def _get_cache_file_path(self, source: DataSource, library: EndfLibrary, isotope: IsotopeInfo, mat: int) -> Path:
+        """
+        Get the path to the cached data file.
+
+        Args:
+            source: The data source (IAEA, NNDC)
+            library: The ENDF library version
+            isotope: IsotopeInfo instance
+            mat: Material number
+
+        Returns:
+            Path to the cached file
+        """
+        z = f"{isotope.atomic_number:03d}"
+        element = isotope.element.capitalize()
+        a = isotope.mass_number
+        filename = f"n_{z}-{element}-{a}_{mat}.dat"
+        return self._get_cache_dir(source, library) / filename
 
     def create_isotope_parameters_from_string(self, isotope_str: str) -> IsotopeParameters:
         """
@@ -46,25 +93,58 @@ class NuclearDataManager:
         if not isotope_info:
             raise ValueError(f"Isotope information for '{isotope_str}' not found.")
 
-        # Create and return an IsotopeParameters instance
-        return IsotopeParameters(isotope_infomation=isotope_info)
+        # Create and return an IsotopeParameters instance with default library
+        return IsotopeParameters(isotope_infomation=isotope_info, endf_library=self.default_library)
 
-    def clear_cache(self) -> None:
-        """Clear the file cache and force reinitialization."""
-        self._cached_files.clear()
-        self._initialize_cache()
-
-    def download_endf_resonance_file(self, isotope: IsotopeInfo, library: str, output_dir: str = ".") -> Path:
+    def clear_cache(self, source: Optional[DataSource] = None, library: Optional[EndfLibrary] = None) -> None:
         """
-        Download and extract resonance parameter section from ENDF library ZIP.
+        Clear the specified cache directories.
 
         Args:
-            isotope: IsotopeInfo instance with atomic_number, element, mass_number, material_number.
-            library: ENDF library version string (e.g., "ENDF-B-VIII.1")
-            output_dir: Directory to write the .par output file
+            source: Optional data source to clear. If None, clears all sources.
+            library: Optional library to clear. If None, clears all libraries.
+        """
+        config = get_config()
+
+        # Determine directories to clear
+        if source is None:
+            # Clear all sources
+            dirs_to_clear = [config.nuclear_data_cache_dir / s.value for s in DataSource]
+        elif library is None:
+            # Clear specific source, all libraries
+            dirs_to_clear = [config.nuclear_data_cache_dir / source.value]
+        else:
+            # Clear specific source and library
+            dirs_to_clear = [config.nuclear_data_cache_dir / source.value / library.value]
+
+        # Delete files in each directory
+        for directory in dirs_to_clear:
+            if directory.exists():
+                for file in directory.glob("*.dat"):
+                    try:
+                        # Call unlink directly on the file path
+                        file.unlink()
+                        logger.info(f"Deleted cached file: {file}")
+                    except Exception as e:
+                        logger.error(f"Failed to delete {file}: {str(e)}")
+
+    def _get_data_from_iaea(
+        self, isotope: IsotopeInfo, library: EndfLibrary, cache_file_path: Path
+    ) -> Tuple[bytes, str]:
+        """
+        Download ENDF data from IAEA.
+
+        Args:
+            isotope: IsotopeInfo instance
+            library: ENDF library version
+            cache_file_path: Path to save cached file
 
         Returns:
-            Path to the saved resonance parameter file
+            Tuple of (file content bytes, original filename)
+
+        Raises:
+            ValueError: If the MAT number cannot be determined
+            requests.RequestException: If download fails
         """
         z = f"{isotope.atomic_number:03d}"
         element = isotope.element.capitalize()
@@ -72,33 +152,124 @@ class NuclearDataManager:
         mat = isotope.material_number
 
         if mat is None:
-            mat = self.get_mat_number(isotope)
+            mat = self.isotope_manager.get_mat_number(isotope)
             if mat is None:
                 raise ValueError(f"Cannot determine MAT number for {isotope}")
 
+        # Construct filename and URL
         filename = f"n_{z}-{element}-{a}_{mat}.zip"
-        url = f"https://www-nds.iaea.org/public/download-endf/{library}/n/{filename}"
+        config = get_config()
+        base_url = config.nuclear_data_sources[DataSource.IAEA.value]
+        url = f"{base_url}/{library}/n/{filename}"
 
         logger.info(f"Downloading ENDF data from {url}")
         response = requests.get(url)
         response.raise_for_status()
 
-        output_name = f"{z}-{element}-{a}.{library.replace('ENDF-', '')}.par"
-        output_path = Path(output_dir) / output_name
+        # Save the zip content to cache
+        cache_file_path.parent.mkdir(parents=True, exist_ok=True)
 
+        # Extract data file from zip
         with zipfile.ZipFile(io.BytesIO(response.content)) as zip_ref:
             for file in zip_ref.namelist():
                 if file.endswith((".endf", ".txt", ".dat")):
                     with zip_ref.open(file) as f:
-                        content = f.read().decode("utf-8")
+                        content = f.read()
 
-                    # Extract only resonance-related lines
-                    resonance_lines = [
-                        line for line in content.splitlines() if line[70:72].strip() in {"2", "32", "34"}
-                    ]
+                    # Write the entire file to cache
+                    with open(cache_file_path, "wb") as f:
+                        f.write(content)
 
-                    output_path.write_text("\n".join(resonance_lines))
-                    logger.info(f"Resonance parameters written to {output_path}")
-                    return output_path
+                    return content, file
 
         raise FileNotFoundError("No suitable ENDF file found inside the ZIP.")
+
+    def _get_data_from_nndc(
+        self, isotope: IsotopeInfo, library: EndfLibrary, cache_file_path: Path
+    ) -> Tuple[bytes, str]:
+        """
+        Download ENDF data from NNDC.
+
+        Args:
+            isotope: IsotopeInfo instance
+            library: ENDF library version
+            cache_file_path: Path to save cached file
+
+        Returns:
+            Tuple of (file content bytes, original filename)
+
+        Raises:
+            NotImplementedError: NNDC download not yet implemented
+        """
+        raise NotImplementedError("NNDC data source is not yet implemented")
+
+    def download_endf_resonance_file(
+        self,
+        isotope: IsotopeInfo,
+        library: str,
+        output_dir: str = ".",
+        source: DataSource = DataSource.IAEA,
+        use_cache: bool = True,
+    ) -> Path:
+        """
+        Download and extract resonance parameter section from ENDF library.
+
+        This function first checks if the file is available in cache. If not, it downloads
+        the complete file to cache and then extracts the resonance parameters.
+
+        Args:
+            isotope: IsotopeInfo instance with atomic_number, element, mass_number, material_number
+            library: ENDF library version string (e.g., "ENDF-B-VIII.0")
+            output_dir: Directory to write the .par output file
+            source: Data source to use (IAEA or NNDC)
+            use_cache: Whether to check cache before downloading
+
+        Returns:
+            Path to the saved resonance parameter file
+        """
+        # Convert string to EndfLibrary enum if needed
+        if isinstance(library, str):
+            try:
+                library = next(lib for lib in EndfLibrary if lib.value == library)
+            except StopIteration:
+                raise ValueError(f"Invalid library: {library}. Valid options: {[lib.value for lib in EndfLibrary]}")
+
+        # Ensure we have a material number
+        if isotope.material_number is None:
+            isotope.material_number = self.isotope_manager.get_mat_number(isotope)
+            if isotope.material_number is None:
+                raise ValueError(f"Cannot determine MAT number for {isotope}")
+
+        # Determine cache file path
+        cache_file_path = self._get_cache_file_path(source, library, isotope, isotope.material_number)
+
+        # Check if file exists in cache
+        content = None
+        if use_cache and cache_file_path.exists():
+            logger.info(f"Using cached ENDF data from {cache_file_path}")
+            with open(cache_file_path, "rb") as f:
+                content = f.read()
+        else:
+            # Download from appropriate source
+            if source == DataSource.IAEA:
+                content, _ = self._get_data_from_iaea(isotope, library, cache_file_path)
+            elif source == DataSource.NNDC:
+                content, _ = self._get_data_from_nndc(isotope, library, cache_file_path)
+            else:
+                raise ValueError(f"Invalid data source: {source}")
+
+        # Extract resonance parameters and write to output file
+        z = f"{isotope.atomic_number:03d}"
+        element = isotope.element.capitalize()
+        a = isotope.mass_number
+
+        output_name = f"{z}-{element}-{a}.{library.value.replace('ENDF-', '')}.par"
+        output_path = Path(output_dir) / output_name
+
+        # Extract resonance parameters
+        content_text = content.decode("utf-8")
+        resonance_lines = [line for line in content_text.splitlines() if line[70:72].strip() in {"2", "32", "34"}]
+
+        output_path.write_text("\n".join(resonance_lines))
+        logger.info(f"Resonance parameters written to {output_path}")
+        return output_path

--- a/src/pleiades/nuclear/models.py
+++ b/src/pleiades/nuclear/models.py
@@ -17,6 +17,13 @@ PositiveFloat = Annotated[float, Field(gt=0)]
 logger = Logger(__name__)
 
 
+class DataSource(str, Enum):
+    """Enumeration of nuclear data sources."""
+
+    IAEA = "IAEA"
+    NNDC = "NNDC"  # To be implemented
+
+
 class EndfLibrary(str, Enum):
     ENDF_B_VIII_1 = "ENDF-B-VIII.1"
     ENDF_B_VIII_0 = "ENDF-B-VIII.0"

--- a/src/pleiades/nuclear/models.py
+++ b/src/pleiades/nuclear/models.py
@@ -25,12 +25,32 @@ class DataSource(str, Enum):
 
 
 class EndfLibrary(str, Enum):
+    """Enumeration of ENDF library versions."""
+
     ENDF_B_VIII_1 = "ENDF-B-VIII.1"
     ENDF_B_VIII_0 = "ENDF-B-VIII.0"
     JEFF_3_3 = "JEFF-3.3"
     JENDL_5 = "JENDL-5"
     CENDL_3_2 = "CENDL-3.2"
     TENDL_2021 = "TENDL-2021"
+
+
+class EndfFilenamePattern(str, Enum):
+    """Filename patterns for different ENDF libraries."""
+
+    MAT_FIRST = "n_{mat}_{z_nozero}-{element}-{a}.zip"  # Format for VIII.0
+    ELEMENT_FIRST = "n_{z}-{element}-{a}_{mat}.zip"  # Format for VIII.1 and others
+
+
+# Mapping of library versions to their filename patterns
+LIBRARY_FILENAME_PATTERNS = {
+    EndfLibrary.ENDF_B_VIII_0: EndfFilenamePattern.MAT_FIRST,
+    EndfLibrary.ENDF_B_VIII_1: EndfFilenamePattern.ELEMENT_FIRST,
+    EndfLibrary.JEFF_3_3: EndfFilenamePattern.ELEMENT_FIRST,
+    EndfLibrary.JENDL_5: EndfFilenamePattern.ELEMENT_FIRST,
+    EndfLibrary.CENDL_3_2: EndfFilenamePattern.ELEMENT_FIRST,
+    EndfLibrary.TENDL_2021: EndfFilenamePattern.ELEMENT_FIRST,
+}
 
 
 class RadiusParameters(BaseModel):

--- a/src/pleiades/nuclear/models.py
+++ b/src/pleiades/nuclear/models.py
@@ -17,11 +17,11 @@ PositiveFloat = Annotated[float, Field(gt=0)]
 logger = Logger(__name__)
 
 
-class DataSource(str, Enum):
-    """Enumeration of nuclear data sources."""
+class DataRetrievalMethod(str, Enum):
+    """Enumeration of methods to retrieve nuclear data."""
 
-    IAEA = "IAEA"
-    NNDC = "NNDC"  # To be implemented
+    DIRECT = "DIRECT"  # Direct download of complete ENDF files
+    API = "API"  # API-based retrieval of specific sections (resonance data only)
 
 
 class EndfLibrary(str, Enum):

--- a/src/pleiades/utils/config.py
+++ b/src/pleiades/utils/config.py
@@ -16,11 +16,11 @@ class PleiadesConfig:
     # Nuclear data configuration
     nuclear_data_cache_dir: Path = field(default_factory=lambda: Path(os.path.expanduser("~/.pleiades/nuclear_data")))
 
-    # Nuclear data sources
+    # Nuclear data retrieval methods and URLs
     nuclear_data_sources: Dict[str, str] = field(
         default_factory=lambda: {
-            "IAEA": "https://www-nds.iaea.org/public/download-endf",
-            "NNDC": "https://www.nndc.bnl.gov/endf/b8.0/data",
+            "DIRECT": "https://www-nds.iaea.org/public/download-endf",  # IAEA direct file download
+            "API": "https://www-nds.iaea.org/exfor/servlet",  # IAEA EXFOR API for section retrieval
         }
     )
 

--- a/src/pleiades/utils/config.py
+++ b/src/pleiades/utils/config.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+"""Global configuration management for PLEIADES."""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+
+@dataclass
+class PleiadesConfig:
+    """Global configuration for PLEIADES."""
+
+    # Nuclear data configuration
+    nuclear_data_cache_dir: Path = field(default_factory=lambda: Path(os.path.expanduser("~/.pleiades/nuclear_data")))
+
+    # Nuclear data sources
+    nuclear_data_sources: Dict[str, str] = field(
+        default_factory=lambda: {
+            "IAEA": "https://www-nds.iaea.org/public/download-endf",
+            "NNDC": "https://www.nndc.bnl.gov/endf/b8.0/data",
+        }
+    )
+
+    # Other configuration sections can be added here as needed
+
+    def __post_init__(self):
+        """Ensure Path objects for all directory configurations."""
+        self.nuclear_data_cache_dir = Path(self.nuclear_data_cache_dir)
+
+    def ensure_directories(self):
+        """Ensure all configured directories exist."""
+        self.nuclear_data_cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert configuration to a dictionary."""
+        result = {}
+        for key, value in self.__dict__.items():
+            if isinstance(value, Path):
+                result[key] = str(value)
+            else:
+                result[key] = value
+        return result
+
+    def save(self, path: Optional[Path] = None) -> Path:
+        """
+        Save configuration to a YAML file.
+
+        Args:
+            path: Path to save configuration file. If None, uses default location.
+
+        Returns:
+            Path to the saved configuration file.
+        """
+        if path is None:
+            path = Path(os.path.expanduser("~/.pleiades/config.yaml"))
+
+        # Ensure directory exists
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Save config as YAML
+        with open(path, "w") as f:
+            yaml.dump(self.to_dict(), f)
+
+        return path
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None) -> "PleiadesConfig":
+        """
+        Load configuration from a YAML file.
+
+        Args:
+            path: Path to load configuration file. If None, uses default location.
+
+        Returns:
+            Loaded configuration object.
+        """
+        if path is None:
+            path = Path(os.path.expanduser("~/.pleiades/config.yaml"))
+
+        if not path.exists():
+            return cls()
+
+        with open(path, "r") as f:
+            config_dict = yaml.safe_load(f)
+
+        if not config_dict:
+            return cls()
+
+        # Convert string paths back to Path objects
+        if "nuclear_data_cache_dir" in config_dict:
+            config_dict["nuclear_data_cache_dir"] = Path(config_dict["nuclear_data_cache_dir"])
+
+        return cls(**config_dict)
+
+
+# Global configuration instance
+_config = None
+
+
+def get_config() -> PleiadesConfig:
+    """Get the global configuration instance."""
+    global _config
+    if _config is None:
+        _config = PleiadesConfig.load()
+        _config.ensure_directories()
+    return _config
+
+
+def set_config(config: PleiadesConfig) -> None:
+    """Set the global configuration instance."""
+    global _config
+    _config = config
+    _config.ensure_directories()
+
+
+def reset_config() -> None:
+    """Reset the global configuration to defaults."""
+    global _config
+    _config = PleiadesConfig()
+    _config.ensure_directories()

--- a/tests/unit/pleiades/nuclear/test_nuclear_manager.py
+++ b/tests/unit/pleiades/nuclear/test_nuclear_manager.py
@@ -1,22 +1,73 @@
 #!/usr/bin/env python
 """Unit tests for the NuclearDataManager class."""
 
-# tests/unit/pleiades/core/test_data_manager.py
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
 import pytest
 
-from pleiades.nuclear.manager import NuclearDataManager
+from pleiades.nuclear.isotopes.models import IsotopeInfo
+from pleiades.nuclear.manager import DataSource, EndfLibrary, NuclearDataManager
+from pleiades.utils.config import PleiadesConfig
 
 
 @pytest.fixture
-def data_manager():
-    """Create a NuclearDataManager instance using actual package data."""
-    return NuclearDataManager()
+def mock_config():
+    """Create a test configuration."""
+    # Create a temporary test configuration
+    test_config = PleiadesConfig(
+        nuclear_data_cache_dir=Path("/tmp/pleiades_test/nuclear_data"),
+        nuclear_data_sources={
+            "IAEA": "https://test-iaea.org/download-endf",
+            "NNDC": "https://test-nndc.org/endf/data",
+        },
+    )
+
+    # Patch the global config to use our test config
+    with patch("pleiades.nuclear.manager.get_config", return_value=test_config):
+        yield test_config
+
+
+@pytest.fixture
+def mock_isotope_info():
+    """Create a mock IsotopeInfo instance."""
+    isotope = IsotopeInfo(
+        name="U-238",
+        element="U",
+        mass_number=238,
+        atomic_number=92,
+        material_number=9237,
+    )
+    return isotope
+
+
+@pytest.fixture
+def mock_isotope_manager():
+    """Create a mock IsotopeManager."""
+    manager = MagicMock()
+    manager.get_isotope_info.return_value = IsotopeInfo(
+        name="U-238",
+        element="U",
+        mass_number=238,
+        atomic_number=92,
+        material_number=9237,
+    )
+    manager.get_mat_number.return_value = 9237
+    return manager
+
+
+@pytest.fixture
+def data_manager(mock_isotope_manager, mock_config):
+    """Create a NuclearDataManager instance with mocked dependencies."""
+    with patch("pleiades.nuclear.manager.Path.mkdir") as mock_mkdir:
+        manager = NuclearDataManager(isotope_manager=mock_isotope_manager)
+        # Ensure cache directories are created
+        assert mock_mkdir.called
+        return manager
 
 
 def test_create_isotope_parameters_from_string_valid(data_manager):
-    """
-    Test creating IsotopeParameters with a valid isotope string using actual data.
-    """
+    """Test creating IsotopeParameters with a valid isotope string."""
     # Call the method under test with a valid isotope string
     isotope_params = data_manager.create_isotope_parameters_from_string("U-238")
 
@@ -27,9 +78,166 @@ def test_create_isotope_parameters_from_string_valid(data_manager):
     assert isotope_params.isotope_infomation.material_number == 9237
     assert isotope_params.abundance is None  # Default value
     assert isotope_params.spin_groups == []  # Default empty list
+    # New test for default library
+    assert isotope_params.endf_library == EndfLibrary.ENDF_B_VIII_0
 
 
-# TODO: Add more tests for other attributes and methods of IsotopeParameters
+def test_initialize_cache(mock_config):
+    """Test that cache directories are created during initialization."""
+    with patch("pleiades.nuclear.manager.Path.mkdir") as mock_mkdir:
+        manager = NuclearDataManager()
+
+        # Should create a directory for each combination of source and library
+        expected_calls = len(DataSource) * len(EndfLibrary)
+        assert mock_mkdir.call_count >= expected_calls
+
+
+def test_get_cache_dir(data_manager, mock_config):
+    """Test getting the cache directory for a specific source and library."""
+    # Test for IAEA source and ENDF-B-VIII.0 library
+    cache_dir = data_manager._get_cache_dir(DataSource.IAEA, EndfLibrary.ENDF_B_VIII_0)
+    expected_path = mock_config.nuclear_data_cache_dir / DataSource.IAEA / EndfLibrary.ENDF_B_VIII_0
+    assert cache_dir == expected_path
+
+
+def test_get_cache_file_path(data_manager, mock_isotope_info):
+    """Test getting the cache file path for a specific file."""
+    # Test for IAEA source, ENDF-B-VIII.0 library, and U-238 isotope
+    cache_file_path = data_manager._get_cache_file_path(
+        DataSource.IAEA, EndfLibrary.ENDF_B_VIII_0, mock_isotope_info, 9237
+    )
+    expected_filename = "n_092-U-238_9237.dat"
+    assert cache_file_path.name == expected_filename
+
+
+def test_download_endf_resonance_file_cache_hit(data_manager, mock_isotope_info, mock_config):
+    """Test downloading ENDF resonance file when it exists in cache."""
+    # Mock the cache file
+    cache_file_path = data_manager._get_cache_file_path(
+        DataSource.IAEA, EndfLibrary.ENDF_B_VIII_0, mock_isotope_info, 9237
+    )
+
+    # Create mock content with resonance data lines
+    mock_content = "Some content\n".encode() + "Line with resonance data  2\n".encode()
+
+    # Patch file exists check and open operations
+    with (
+        patch("pleiades.nuclear.manager.Path.exists", return_value=True),
+        patch("builtins.open", Mock()),
+        patch("pleiades.nuclear.manager.Path.write_text") as mock_write,
+        patch("builtins.open", mock_open := MagicMock()),
+    ):
+        # Configure mock to return our content when reading
+        mock_open.return_value.__enter__.return_value.read.return_value = mock_content
+
+        # Call the method under test
+        output_path = data_manager.download_endf_resonance_file(
+            mock_isotope_info, EndfLibrary.ENDF_B_VIII_0, output_dir="/tmp"
+        )
+
+        # Verify the output path is correct
+        assert output_path.name == "092-U-238.B-VIII.0.par"
+        assert output_path.parent == Path("/tmp")
+
+        # Verify we used the cached data
+        mock_open.assert_called()
+
+
+@patch("pleiades.nuclear.manager.requests.get")
+def test_download_endf_resonance_file_cache_miss(mock_get, data_manager, mock_isotope_info, mock_config):
+    """Test downloading ENDF resonance file when it doesn't exist in cache."""
+    # Set up mocks
+    mock_response = Mock()
+    mock_response.content = b"Mock ZIP content"
+    mock_get.return_value = mock_response
+    mock_response.raise_for_status = Mock()
+
+    # Set up the mock for _get_data_from_iaea method instead of trying to mock zipfile
+    with (
+        patch.object(
+            data_manager, "_get_data_from_iaea", return_value=(b"Line with resonance data  2\n", "file.dat")
+        ) as mock_get_data,
+        patch("pleiades.nuclear.manager.Path.exists", return_value=False),
+        patch("pleiades.nuclear.manager.Path.write_text") as mock_write,
+    ):
+        # Call the method under test
+        output_path = data_manager.download_endf_resonance_file(
+            mock_isotope_info, EndfLibrary.ENDF_B_VIII_0, output_dir="/tmp"
+        )
+
+        # Verify the output path is correct
+        assert output_path.name == "092-U-238.B-VIII.0.par"
+        assert output_path.parent == Path("/tmp")
+
+        # Verify our mock was called
+        mock_get_data.assert_called_once()
+
+
+def test_clear_cache(data_manager, mock_config):
+    """Test clearing the cache."""
+    with (
+        patch("pleiades.nuclear.manager.Path.exists", return_value=True),
+        patch("pleiades.nuclear.manager.Path.glob") as mock_glob,
+    ):
+        # Create a new test for each case to avoid issues with multiple calls
+
+        # Test 1: Clearing all caches
+        mock_file1 = MagicMock()
+        mock_file2 = MagicMock()
+        mock_glob.return_value = [mock_file1, mock_file2]
+
+        # Test clearing all caches
+        data_manager.clear_cache()
+        assert mock_glob.call_count > 0
+
+        # Verify each returned mock file had unlink called
+        assert mock_file1.unlink.called
+        assert mock_file2.unlink.called
+
+    # Test 2: Clearing specific source
+    with (
+        patch("pleiades.nuclear.manager.Path.exists", return_value=True),
+        patch("pleiades.nuclear.manager.Path.glob") as mock_glob,
+    ):
+        mock_file1 = MagicMock()
+        mock_file2 = MagicMock()
+        mock_glob.return_value = [mock_file1, mock_file2]
+
+        data_manager.clear_cache(source=DataSource.IAEA)
+        assert mock_glob.call_count > 0
+        assert mock_file1.unlink.called
+        assert mock_file2.unlink.called
+
+    # Test 3: Clearing specific source and library
+    with (
+        patch("pleiades.nuclear.manager.Path.exists", return_value=True),
+        patch("pleiades.nuclear.manager.Path.glob") as mock_glob,
+    ):
+        mock_file1 = MagicMock()
+        mock_file2 = MagicMock()
+        mock_glob.return_value = [mock_file1, mock_file2]
+
+        data_manager.clear_cache(source=DataSource.IAEA, library=EndfLibrary.ENDF_B_VIII_0)
+        assert mock_glob.call_count > 0
+        assert mock_file1.unlink.called
+        assert mock_file2.unlink.called
+
+
+def test_nndc_not_implemented(data_manager, mock_isotope_info):
+    """Test that NNDC download raises NotImplementedError."""
+    with pytest.raises(NotImplementedError):
+        # Try to download from NNDC source
+        data_manager.download_endf_resonance_file(mock_isotope_info, EndfLibrary.ENDF_B_VIII_0, source=DataSource.NNDC)
+
+
+# Helper for tests
+def mock_open(*args, **kwargs):
+    """Mock implementation of built-in open function."""
+    m = MagicMock()
+    m.__enter__.return_value = m
+    m.read.return_value = b"Mock file content"
+    return m
+
 
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/unit/pleiades/nuclear/test_nuclear_manager.py
+++ b/tests/unit/pleiades/nuclear/test_nuclear_manager.py
@@ -106,6 +106,14 @@ def test_get_cache_file_path(data_manager, mock_isotope_info):
     cache_file_path = data_manager._get_cache_file_path(
         DataSource.IAEA, EndfLibrary.ENDF_B_VIII_0, mock_isotope_info, 9237
     )
+    # ENDF-B-VIII.0 uses MAT_FIRST pattern with non-zero-padded Z
+    expected_filename = "n_9237_92-U-238.dat"
+    assert cache_file_path.name == expected_filename
+
+    # Also test with a library that uses ELEMENT_FIRST pattern
+    cache_file_path = data_manager._get_cache_file_path(
+        DataSource.IAEA, EndfLibrary.ENDF_B_VIII_1, mock_isotope_info, 9237
+    )
     expected_filename = "n_092-U-238_9237.dat"
     assert cache_file_path.name == expected_filename
 

--- a/tests/unit/pleiades/utils/test_utils_config.py
+++ b/tests/unit/pleiades/utils/test_utils_config.py
@@ -23,10 +23,10 @@ class TestPleiadesConfig:
         assert config.nuclear_data_cache_dir == expected_path
 
         # Check default nuclear data sources
-        assert "IAEA" in config.nuclear_data_sources
-        assert "NNDC" in config.nuclear_data_sources
-        assert config.nuclear_data_sources["IAEA"] == "https://www-nds.iaea.org/public/download-endf"
-        assert config.nuclear_data_sources["NNDC"] == "https://www.nndc.bnl.gov/endf/b8.0/data"
+        assert "DIRECT" in config.nuclear_data_sources
+        assert "API" in config.nuclear_data_sources
+        assert config.nuclear_data_sources["DIRECT"] == "https://www-nds.iaea.org/public/download-endf"
+        assert config.nuclear_data_sources["API"] == "https://www-nds.iaea.org/exfor/servlet"
 
     def test_custom_initialization(self):
         """Test custom initialization of PleiadesConfig."""
@@ -117,8 +117,8 @@ class TestPleiadesConfig:
             # Verify default values
             expected_path = Path(os.path.expanduser("~/.pleiades/nuclear_data"))
             assert config.nuclear_data_cache_dir == expected_path
-            assert "IAEA" in config.nuclear_data_sources
-            assert "NNDC" in config.nuclear_data_sources
+            assert "DIRECT" in config.nuclear_data_sources
+            assert "API" in config.nuclear_data_sources
 
     def test_load_empty_file(self):
         """Test loading from empty file returns default config."""
@@ -135,8 +135,8 @@ class TestPleiadesConfig:
             # Verify default values
             expected_path = Path(os.path.expanduser("~/.pleiades/nuclear_data"))
             assert config.nuclear_data_cache_dir == expected_path
-            assert "IAEA" in config.nuclear_data_sources
-            assert "NNDC" in config.nuclear_data_sources
+            assert "DIRECT" in config.nuclear_data_sources
+            assert "API" in config.nuclear_data_sources
 
 
 class TestGlobalConfigFunctions:

--- a/tests/unit/pleiades/utils/test_utils_config.py
+++ b/tests/unit/pleiades/utils/test_utils_config.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+"""Unit tests for global configuration management."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from pleiades.utils.config import PleiadesConfig, get_config, reset_config, set_config
+
+
+class TestPleiadesConfig:
+    """Test suite for PleiadesConfig class."""
+
+    def test_default_initialization(self):
+        """Test default initialization of PleiadesConfig."""
+        config = PleiadesConfig()
+
+        # Check default nuclear data cache dir
+        expected_path = Path(os.path.expanduser("~/.pleiades/nuclear_data"))
+        assert config.nuclear_data_cache_dir == expected_path
+
+        # Check default nuclear data sources
+        assert "IAEA" in config.nuclear_data_sources
+        assert "NNDC" in config.nuclear_data_sources
+        assert config.nuclear_data_sources["IAEA"] == "https://www-nds.iaea.org/public/download-endf"
+        assert config.nuclear_data_sources["NNDC"] == "https://www.nndc.bnl.gov/endf/b8.0/data"
+
+    def test_custom_initialization(self):
+        """Test custom initialization of PleiadesConfig."""
+        custom_path = Path("/custom/path")
+        custom_sources = {"TEST": "https://test.com"}
+
+        config = PleiadesConfig(nuclear_data_cache_dir=custom_path, nuclear_data_sources=custom_sources)
+
+        assert config.nuclear_data_cache_dir == custom_path
+        assert config.nuclear_data_sources == custom_sources
+
+    def test_post_init_conversion(self):
+        """Test __post_init__ conversion of string paths to Path objects."""
+        config = PleiadesConfig(nuclear_data_cache_dir="/test/string/path")
+
+        assert isinstance(config.nuclear_data_cache_dir, Path)
+        assert config.nuclear_data_cache_dir == Path("/test/string/path")
+
+    def test_ensure_directories(self, monkeypatch):
+        """Test directory creation functionality."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_path = Path(tmpdir) / "nuclear_data"
+
+            # Create config with temp path
+            config = PleiadesConfig(nuclear_data_cache_dir=temp_path)
+
+            # Verify directory doesn't exist yet
+            assert not temp_path.exists()
+
+            # Create directories
+            config.ensure_directories()
+
+            # Verify directory was created
+            assert temp_path.exists()
+            assert temp_path.is_dir()
+
+    def test_to_dict(self):
+        """Test conversion of config to dictionary."""
+        custom_path = Path("/custom/path")
+        custom_sources = {"TEST": "https://test.com"}
+
+        config = PleiadesConfig(nuclear_data_cache_dir=custom_path, nuclear_data_sources=custom_sources)
+
+        config_dict = config.to_dict()
+
+        # Path should be converted to string
+        assert config_dict["nuclear_data_cache_dir"] == str(custom_path)
+        assert config_dict["nuclear_data_sources"] == custom_sources
+
+    def test_save_and_load(self):
+        """Test saving and loading config to/from file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a config with custom values
+            temp_path = Path(tmpdir) / "nuclear_data"
+            custom_sources = {"TEST": "https://test.com"}
+
+            config = PleiadesConfig(nuclear_data_cache_dir=temp_path, nuclear_data_sources=custom_sources)
+
+            # Save to temp file
+            save_path = Path(tmpdir) / "config.yaml"
+            actual_save_path = config.save(save_path)
+
+            # Verify save path
+            assert actual_save_path == save_path
+            assert save_path.exists()
+
+            # Verify file content
+            with open(save_path, "r") as f:
+                saved_data = yaml.safe_load(f)
+                assert saved_data["nuclear_data_cache_dir"] == str(temp_path)
+                assert saved_data["nuclear_data_sources"] == custom_sources
+
+            # Load config from saved file
+            loaded_config = PleiadesConfig.load(save_path)
+
+            # Verify loaded config matches original
+            assert loaded_config.nuclear_data_cache_dir == temp_path
+            assert loaded_config.nuclear_data_sources == custom_sources
+
+    def test_load_nonexistent_file(self):
+        """Test loading from nonexistent file returns default config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nonexistent_path = Path(tmpdir) / "nonexistent.yaml"
+
+            # Load should return default config
+            config = PleiadesConfig.load(nonexistent_path)
+
+            # Verify default values
+            expected_path = Path(os.path.expanduser("~/.pleiades/nuclear_data"))
+            assert config.nuclear_data_cache_dir == expected_path
+            assert "IAEA" in config.nuclear_data_sources
+            assert "NNDC" in config.nuclear_data_sources
+
+    def test_load_empty_file(self):
+        """Test loading from empty file returns default config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty_path = Path(tmpdir) / "empty.yaml"
+
+            # Create empty file
+            with open(empty_path, "w") as f:
+                f.write("")
+
+            # Load should return default config
+            config = PleiadesConfig.load(empty_path)
+
+            # Verify default values
+            expected_path = Path(os.path.expanduser("~/.pleiades/nuclear_data"))
+            assert config.nuclear_data_cache_dir == expected_path
+            assert "IAEA" in config.nuclear_data_sources
+            assert "NNDC" in config.nuclear_data_sources
+
+
+class TestGlobalConfigFunctions:
+    """Test suite for global configuration functions."""
+
+    def test_get_config(self, monkeypatch):
+        """Test get_config returns a valid config and initializes directories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Mock home directory to use our temp dir
+            monkeypatch.setattr(os.path, "expanduser", lambda path: path.replace("~", tmpdir))
+
+            # Reset global state
+            monkeypatch.setattr("pleiades.utils.config._config", None)
+
+            # Get config
+            config = get_config()
+
+            # Verify it's a PleiadesConfig instance
+            assert isinstance(config, PleiadesConfig)
+
+            # Verify directories were created
+            expected_path = Path(tmpdir) / ".pleiades" / "nuclear_data"
+            assert expected_path.exists()
+            assert expected_path.is_dir()
+
+    def test_set_config(self, monkeypatch):
+        """Test set_config updates the global config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a custom config with path in the temporary directory
+            custom_path = Path(tmpdir) / "custom/path"
+            custom_config = PleiadesConfig(nuclear_data_cache_dir=custom_path)
+
+            monkeypatch.setattr("pleiades.utils.config._config", None)
+
+            # Set custom config
+            set_config(custom_config)
+
+            # Get config and verify it matches our custom config
+            config = get_config()
+            assert config is custom_config
+            assert config.nuclear_data_cache_dir == custom_path
+
+            # Verify directory was created
+            assert custom_path.exists()
+            assert custom_path.is_dir()
+
+    def test_reset_config(self, monkeypatch):
+        """Test reset_config resets to default config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Mock home directory to use our temp dir for the default path
+            monkeypatch.setattr(os.path, "expanduser", lambda path: path.replace("~", tmpdir))
+
+            # Create a custom config with a different path
+            custom_path = Path(tmpdir) / "custom/path"
+            custom_config = PleiadesConfig(nuclear_data_cache_dir=custom_path)
+
+            monkeypatch.setattr("pleiades.utils.config._config", custom_config)
+
+            # Reset config
+            reset_config()
+
+            # Get config and verify it's a default config
+            config = get_config()
+            assert config is not custom_config
+            expected_path = Path(tmpdir) / ".pleiades" / "nuclear_data"
+            assert config.nuclear_data_cache_dir == expected_path
+            assert expected_path.exists()
+            assert expected_path.is_dir()
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
This PR introduces the following changes:

- Add a global configuration system for PLEIADES
- Add caching capability for both DIRECT and API access to ENDF files
- Add corresponding unit test
- Add example notebook for usage demonstration
- Switch log library to loguru (some additional changes is still needed for individual module)

> EWM item: [10646](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=10646)
> #88 #89 #91 

## Testing instructions

- Clone repo and check out feature branch
- Run `pixi run test` to run all unit test locally
- Go through notebook, `notebook/tutorial/pleiades_endf_retrieval_caching.ipynb`

---
## Summary [AI]

This pull request introduces significant changes to the PLEIADES project, focusing on transitioning to the Loguru logging library, enhancing the `NuclearDataManager` class, and updating the project's configuration and dependencies. Below is a summary of the most important changes:

### Migration to Loguru Logging
* Added a new migration guide in `docs/development/migration_to_loguru.md` to help developers transition from Python's native logging to Loguru. The guide includes examples, benefits, and advanced usage scenarios.
* Updated dependencies in `pyproject.toml` to include `loguru` (version `>=0.7.2,<0.8`). [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R22) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R134)
* Introduced `loguru_logger` and `configure_logger` in `src/pleiades/__init__.py` for centralized logging configuration.

### Enhancements to `NuclearDataManager`
* Refactored `src/pleiades/nuclear/manager.py` to add caching, retrieval, and processing of nuclear data files. This includes methods for initializing cache directories, downloading ENDF data via direct or API methods, and clearing cached files. [[1]](diffhunk://#diff-72f57b9ad4180e0579a823c0a696fa2bceabf8d95ecf5feeae046f711794ad52R37-R95) [[2]](diffhunk://#diff-72f57b9ad4180e0579a823c0a696fa2bceabf8d95ecf5feeae046f711794ad52L49-R400)
* Introduced support for multiple ENDF libraries and retrieval methods (`DIRECT` and `API`) with corresponding cache management.

### Test and Build Improvements
* Enhanced the `test` task in `pyproject.toml` to include code coverage reporting and added a new `clean-test` task for cleaning test artifacts.

### Documentation and Metadata
* Added a package-level docstring in `src/pleiades/__init__.py` describing the purpose of PLEIADES.

These changes improve logging, streamline nuclear data management, and enhance the project's overall maintainability and usability.
