### PR TITLE
Promote v2.0 from qa to main

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: prefix-dev/setup-pixi@v0.8.5
+      - uses: prefix-dev/setup-pixi@v0.9.1
         with:
           pixi-version: v0.41.4
           manifest-path: pyproject.toml
@@ -39,7 +39,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v5
-      - uses: prefix-dev/setup-pixi@v0.8.5
+      - uses: prefix-dev/setup-pixi@v0.9.1
         with:
           pixi-version: v0.41.4
           manifest-path: pyproject.toml

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: prefix-dev/setup-pixi@v0.8.5
+      - uses: prefix-dev/setup-pixi@v0.9.1
         with:
           pixi-version: v0.41.4
           manifest-path: pyproject.toml

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Set up pixi
-        uses: prefix-dev/setup-pixi@v0.8.5
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
           run-install: false
       - name: Update lockfiles


### PR DESCRIPTION
## Summary
Promoting v2.0 release from qa to main following proper git-flow.

## Changes
- GitHub Actions dependencies updates from Dependabot
- All v2.0 features already merged

## Testing
✅ All tests passing in qa branch
✅ v2.0 tag created

This is the final step to complete the v2.0 release.