### PR TITLE
fix: include isotope data files in package distribution

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -6661,8 +6661,8 @@ packages:
   timestamp: 1756227402815
 - pypi: ./
   name: pleiades-neutron
-  version: 2.2.0.dev3+d202510071649
-  sha256: 46976c8fe86d483b07c9319e885c9b2f5cc22caef3a57b25e890586d7b2720ca
+  version: 2.1.0.dev10+d202510271845
+  sha256: 74832b7841b7d85e43041ad642b66430d41316cb743b40ede148e6203ff4f151
   requires_dist:
   - numpy
   - scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ where = ["src"]
 exclude = ["tests*", "docs*", "notebooks*"]
 
 [tool.setuptools.package-data]
-"*" = ["*.yml","*.yaml","*.ini","**/*.ui","**/*.json", "**/icons/*"]
+"*" = ["*.yml","*.yaml","*.ini","**/*.ui","**/*.json", "**/icons/*", "*.info", "*.mas20", "*.list", "README"]
 
 # -------------------------------- #
 # ----- Pytest configuration ----- #


### PR DESCRIPTION
## Summary

- Fixed packaging configuration to include isotope data files that were missing from distributed packages
- Added file extensions `*.info`, `*.mas20`, `*.list`, and `README` to `tool.setuptools.package-data` in `pyproject.toml`
- Updated `pixi.lock` after pyproject.toml modification

## Problem

The isotope data files located in `src/pleiades/nuclear/isotopes/files/` were not being included when building the package due to missing file extension patterns in the setuptools configuration. This would cause runtime failures for users installing via pip when the `IsotopeManager` tried to access these required data files.

Missing files:
- `isotopes.info` (23 KB) - Isotope abundance and spin data
- `mass.mas20` (462 KB) - Atomic mass adjustment data  
- `neutrons.list` (42 KB) - ENDF MAT number mappings
- `README` (863 bytes) - File documentation

## Solution

Updated `[tool.setuptools.package-data]` in `pyproject.toml` to include the missing file extensions:

```toml
"*" = ["*.yml","*.yaml","*.ini","**/*.ui","**/*.json", "**/icons/*", "*.info", "*.mas20", "*.list", "README"]
```

## Verification

✅ All unit tests passed (1029 passed, 14 skipped)
✅ Built wheel package using `pixi run build-pypi`
✅ Inspected wheel contents - confirmed all four isotope data files are included:
   - `pleiades/nuclear/isotopes/files/README`
   - `pleiades/nuclear/isotopes/files/isotopes.info`
   - `pleiades/nuclear/isotopes/files/mass.mas20`
   - `pleiades/nuclear/isotopes/files/neutrons.list`

## Test plan

- [x] Build wheel package using `pixi run build-pypi`
- [x] Inspect wheel contents to verify isotope data files are included
- [x] Run unit tests: `pixi run test` - 1029 passed, 14 skipped
- [x] Verify `IsotopeManager` tests pass (tests access data files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)