### PR TITLE
Add pleiades.workflows module with high-level APIs

### DIFF
--- a/src/pleiades/workflows/__init__.py
+++ b/src/pleiades/workflows/__init__.py
@@ -1,0 +1,53 @@
+"""PLEIADES high-level workflow APIs.
+
+This module provides simple, high-level functions for common PLEIADES
+operations. These functions orchestrate multiple lower-level APIs to
+perform complete analysis workflows.
+
+Example:
+    >>> from pleiades.workflows import validate_dataset, analyze_resonance
+    >>>
+    >>> # Validate dataset before analysis
+    >>> validation = validate_dataset("/path/to/dataset")
+    >>> if validation.valid:
+    ...     print(f"Dataset ready for {validation.recommended_workflow.value} workflow")
+    ...
+    >>> # Run analysis
+    >>> result = analyze_resonance("/path/to/dataset")
+    >>> if result.success:
+    ...     print(f"Chi²/dof: {result.reduced_chi_squared:.3f}")
+    ...     print(f"Fit quality: {result.fit_quality.value}")
+"""
+
+from __future__ import annotations
+
+from pleiades.workflows.models import (
+    FitQuality,
+    ManifestData,
+    MaterialProperties,
+    ResonanceResult,
+    ValidationIssue,
+    ValidationResult,
+    WorkflowType,
+)
+from pleiades.workflows.resonance import (
+    analyze_resonance,
+    extract_manifest,
+    validate_dataset,
+)
+
+__all__ = [
+    # Main workflow functions
+    "analyze_resonance",
+    "validate_dataset",
+    "extract_manifest",
+    # Result models
+    "ResonanceResult",
+    "ValidationResult",
+    "ValidationIssue",
+    "ManifestData",
+    "MaterialProperties",
+    # Enums
+    "WorkflowType",
+    "FitQuality",
+]

--- a/src/pleiades/workflows/__init__.py
+++ b/src/pleiades/workflows/__init__.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from pleiades.workflows.models import (
     FitQuality,
+    IsotopeResult,
     ManifestData,
     MaterialProperties,
     ResonanceResult,
@@ -47,6 +48,7 @@ __all__ = [
     "ValidationIssue",
     "ManifestData",
     "MaterialProperties",
+    "IsotopeResult",
     # Enums
     "WorkflowType",
     "FitQuality",

--- a/src/pleiades/workflows/__init__.py
+++ b/src/pleiades/workflows/__init__.py
@@ -15,8 +15,12 @@ Example:
     >>> # Run analysis
     >>> result = analyze_resonance("/path/to/dataset")
     >>> if result.success:
-    ...     print(f"Chi²/dof: {result.reduced_chi_squared:.3f}")
-    ...     print(f"Fit quality: {result.fit_quality.value}")
+    ...     if result.reduced_chi_squared is not None:
+    ...         print(f"Chi²/dof: {result.reduced_chi_squared:.3f}")
+    ...     if result.fit_quality is not None:
+    ...         print(f"Fit quality: {result.fit_quality.value}")
+    >>> else:
+    ...     print(f"Analysis failed: {result.error_message}")
 """
 
 from __future__ import annotations

--- a/src/pleiades/workflows/models.py
+++ b/src/pleiades/workflows/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -105,7 +105,7 @@ class ResonanceResult(BaseModel):
 class ValidationIssue(BaseModel):
     """Single validation issue found in dataset."""
 
-    severity: str = Field(..., description="Issue severity: 'error' or 'warning'")
+    severity: Literal["error", "warning"] = Field(..., description="Issue severity")
     message: str = Field(..., description="Description of the issue")
     path: Path | None = Field(None, description="Path related to the issue")
 

--- a/src/pleiades/workflows/models.py
+++ b/src/pleiades/workflows/models.py
@@ -1,0 +1,175 @@
+"""Pydantic models for PLEIADES workflow results.
+
+This module defines structured result types for workflow operations,
+enabling type-safe results and consistent output formatting.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WorkflowType(str, Enum):
+    """Type of resonance analysis workflow."""
+
+    FULL = "full"
+    SIMPLIFIED = "simplified"
+
+
+class FitQuality(str, Enum):
+    """Quality assessment of SAMMY fit."""
+
+    EXCELLENT = "excellent"
+    GOOD = "good"
+    ACCEPTABLE = "acceptable"
+    POOR = "poor"
+
+    @classmethod
+    def from_chi_squared(cls, reduced_chi_sq: float) -> FitQuality:
+        """Determine fit quality from reduced chi-squared value."""
+        if reduced_chi_sq < 1.2:
+            return cls.EXCELLENT
+        elif reduced_chi_sq < 2.0:
+            return cls.GOOD
+        elif reduced_chi_sq < 5.0:
+            return cls.ACCEPTABLE
+        else:
+            return cls.POOR
+
+
+class MaterialProperties(BaseModel):
+    """Material properties for resonance analysis."""
+
+    density_g_cm3: float = Field(..., description="Material density in g/cm³")
+    atomic_mass_amu: float = Field(..., description="Atomic mass in amu")
+    temperature_k: float | None = Field(None, description="Sample temperature in Kelvin")
+
+
+class IsotopeResult(BaseModel):
+    """Results for a single isotope in the analysis."""
+
+    isotope: str = Field(..., description="Isotope identifier (e.g., 'Au-197')")
+    abundance: float = Field(..., description="Fitted abundance fraction")
+    abundance_uncertainty: float | None = Field(None, description="Uncertainty in abundance")
+
+
+class ResonanceResult(BaseModel):
+    """Complete results from resonance analysis workflow.
+
+    This model captures all outputs from a successful resonance analysis,
+    including fit quality metrics, physical parameters, and output file paths.
+    """
+
+    success: bool = Field(..., description="Whether the analysis completed successfully")
+    workflow_type: WorkflowType = Field(..., description="Type of workflow executed")
+
+    # Primary isotope info
+    primary_isotope: str = Field(..., description="Primary isotope analyzed")
+    isotopes_analyzed: list[str] = Field(default_factory=list, description="All isotopes in analysis")
+
+    # Fit results
+    chi_squared: float | None = Field(None, description="Chi-squared value")
+    reduced_chi_squared: float | None = Field(None, description="Reduced chi-squared (chi²/dof)")
+    degrees_of_freedom: int | None = Field(None, description="Degrees of freedom")
+    fit_quality: FitQuality | None = Field(None, description="Qualitative fit assessment")
+
+    # Physical parameters (fitted)
+    number_density: float | None = Field(None, description="Number density (atoms/barn-cm)")
+    temperature_k: float | None = Field(None, description="Effective temperature (K)")
+
+    # Isotope-specific results (for multi-isotope analysis)
+    isotope_results: list[IsotopeResult] = Field(default_factory=list, description="Per-isotope fit results")
+
+    # Output paths
+    output_dir: Path | None = Field(None, description="SAMMY output directory")
+    lpt_file: Path | None = Field(None, description="SAMMY .LPT log file")
+    lst_file: Path | None = Field(None, description="SAMMY .LST listing file")
+    par_file: Path | None = Field(None, description="Updated .PAR parameter file")
+    plot_file: Path | None = Field(None, description="Generated fit plot")
+
+    # Error info (if success=False)
+    error_message: str | None = Field(None, description="Error message if analysis failed")
+    error_step: str | None = Field(None, description="Workflow step where error occurred")
+
+    # Workflow metadata
+    runtime_seconds: float | None = Field(None, description="Total execution time")
+    workflow_steps: dict[str, str] = Field(default_factory=dict, description="Status of each workflow step")
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class ValidationIssue(BaseModel):
+    """Single validation issue found in dataset."""
+
+    severity: str = Field(..., description="Issue severity: 'error' or 'warning'")
+    message: str = Field(..., description="Description of the issue")
+    path: Path | None = Field(None, description="Path related to the issue")
+
+
+class ValidationResult(BaseModel):
+    """Results from dataset validation.
+
+    Validates that a dataset has the required structure and files
+    for resonance analysis.
+    """
+
+    valid: bool = Field(..., description="Whether the dataset is valid for analysis")
+    dataset_path: Path = Field(..., description="Path to the validated dataset")
+
+    # Detected workflow type
+    can_run_full_workflow: bool = Field(False, description="Dataset supports full imaging workflow")
+    can_run_simplified_workflow: bool = Field(False, description="Dataset has pre-existing SAMMY files")
+    recommended_workflow: WorkflowType | None = Field(None, description="Recommended workflow type")
+
+    # Dataset contents
+    has_raw_data: bool = Field(False, description="Has raw imaging data")
+    has_open_beam: bool = Field(False, description="Has open beam normalization data")
+    has_metadata: bool = Field(False, description="Has NeXus metadata")
+    has_sammy_files: bool = Field(False, description="Has pre-existing SAMMY files")
+    has_manifest: bool = Field(False, description="Has sMCP manifest file")
+
+    # Validation issues
+    issues: list[ValidationIssue] = Field(default_factory=list, description="All validation issues found")
+
+    @property
+    def errors(self) -> list[ValidationIssue]:
+        """Get only error-level issues."""
+        return [i for i in self.issues if i.severity == "error"]
+
+    @property
+    def warnings(self) -> list[ValidationIssue]:
+        """Get only warning-level issues."""
+        return [i for i in self.issues if i.severity == "warning"]
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class ManifestData(BaseModel):
+    """Parsed manifest data from dataset.
+
+    Structured representation of the sMCP manifest frontmatter
+    and processing instructions.
+    """
+
+    name: str = Field(..., description="Unique dataset identifier")
+    description: str = Field(..., description="Human-readable description")
+    version: str = Field(..., description="Manifest version (semver)")
+    created: str = Field(..., description="ISO-8601 creation timestamp")
+
+    # Experiment metadata
+    facility: str | None = Field(None, description="Facility identifier (e.g., 'SNS')")
+    beamline: str | None = Field(None, description="Beamline name (e.g., 'VENUS')")
+    detector: str | None = Field(None, description="Detector type")
+    sample_id: str | None = Field(None, description="Sample identifier")
+
+    # Analysis parameters
+    isotope: str | None = Field(None, description="Primary isotope (e.g., 'Au-197')")
+    material_properties: MaterialProperties | None = Field(None, description="Material physical properties")
+
+    # Raw content
+    body: str = Field("", description="Markdown body with processing instructions")
+    raw_frontmatter: dict[str, Any] = Field(default_factory=dict, description="Raw YAML frontmatter")

--- a/src/pleiades/workflows/models.py
+++ b/src/pleiades/workflows/models.py
@@ -6,11 +6,12 @@ enabling type-safe results and consistent output formatting.
 
 from __future__ import annotations
 
+import math
 from enum import Enum
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class WorkflowType(str, Enum):
@@ -30,7 +31,19 @@ class FitQuality(str, Enum):
 
     @classmethod
     def from_chi_squared(cls, reduced_chi_sq: float) -> FitQuality:
-        """Determine fit quality from reduced chi-squared value."""
+        """Determine fit quality from reduced chi-squared value.
+
+        Args:
+            reduced_chi_sq: Reduced chi-squared value (must be non-negative and finite).
+
+        Returns:
+            FitQuality enum value based on the chi-squared value.
+
+        Raises:
+            ValueError: If reduced_chi_sq is negative, NaN, or infinite.
+        """
+        if not math.isfinite(reduced_chi_sq) or reduced_chi_sq < 0:
+            raise ValueError(f"Invalid reduced chi-squared value: {reduced_chi_sq}")
         if reduced_chi_sq < 1.2:
             return cls.EXCELLENT
         elif reduced_chi_sq < 2.0:
@@ -47,6 +60,22 @@ class MaterialProperties(BaseModel):
     density_g_cm3: float = Field(..., description="Material density in g/cm³")
     atomic_mass_amu: float = Field(..., description="Atomic mass in amu")
     temperature_k: float | None = Field(None, description="Sample temperature in Kelvin")
+
+    @field_validator("density_g_cm3", "atomic_mass_amu")
+    @classmethod
+    def validate_positive(cls, v: float, info) -> float:
+        """Validate that physical properties are positive."""
+        if v <= 0:
+            raise ValueError(f"{info.field_name} must be positive, got {v}")
+        return v
+
+    @field_validator("temperature_k")
+    @classmethod
+    def validate_temperature(cls, v: float | None) -> float | None:
+        """Validate that temperature is positive if provided."""
+        if v is not None and v <= 0:
+            raise ValueError(f"temperature_k must be positive, got {v}")
+        return v
 
 
 class IsotopeResult(BaseModel):

--- a/src/pleiades/workflows/resonance.py
+++ b/src/pleiades/workflows/resonance.py
@@ -126,15 +126,6 @@ def validate_dataset(dataset_path: str | Path) -> ValidationResult:
             )
         )
 
-    if not has_raw and not has_sammy_files:
-        issues.append(
-            ValidationIssue(
-                severity="error",
-                message="No raw data directory found",
-                path=raw_dir,
-            )
-        )
-
     if has_raw and not has_ob:
         issues.append(
             ValidationIssue(
@@ -187,11 +178,13 @@ def validate_dataset(dataset_path: str | Path) -> ValidationResult:
                 )
 
     # Determine recommended workflow
+    # Prefer simplified workflow when both are available since full workflow
+    # is not yet implemented (see #172)
     recommended = None
-    if can_run_full:
-        recommended = WorkflowType.FULL
-    elif can_run_simplified:
+    if can_run_simplified:
         recommended = WorkflowType.SIMPLIFIED
+    elif can_run_full:
+        recommended = WorkflowType.FULL
 
     # Dataset is valid if there are no errors
     has_errors = any(i.severity == "error" for i in issues)
@@ -251,11 +244,12 @@ def extract_manifest(dataset_path: str | Path) -> ManifestData | None:
 
     logger.info(f"Parsing manifest: {manifest_path}")
 
-    with open(manifest_path) as f:
+    with open(manifest_path, encoding="utf-8") as f:
         content = f.read()
 
     # Split YAML frontmatter from Markdown body
-    parts = content.split("---")
+    # Use maxsplit=2 to handle "---" in the markdown body (e.g., horizontal rules)
+    parts = content.split("---", 2)
     if len(parts) < 3:
         raise ValueError(f"Invalid manifest format in {manifest_path}: missing YAML frontmatter")
 
@@ -267,7 +261,7 @@ def extract_manifest(dataset_path: str | Path) -> ManifestData | None:
     if "created" in frontmatter and hasattr(frontmatter["created"], "isoformat"):
         frontmatter["created"] = frontmatter["created"].isoformat()
 
-    # Extract markdown body
+    # Extract markdown body (everything after the second "---")
     body = parts[2].strip()
 
     # Parse material properties if present
@@ -330,9 +324,8 @@ def analyze_resonance(
 
     Returns:
         ResonanceResult with analysis results and output paths.
-
-    Raises:
-        ValueError: If dataset is invalid and skip_validation=False.
+        If the dataset is invalid and skip_validation=False, returns a
+        ResonanceResult with success=False and an appropriate error message.
 
     Example:
         >>> result = analyze_resonance("/data/Au197_sample")
@@ -367,6 +360,8 @@ def analyze_resonance(
         workflow_steps["validation"] = "completed"
 
         # Determine workflow type
+        # Prefer simplified workflow when both are available since full workflow
+        # is not yet implemented (see #172) - matches validate_dataset logic
         if validation.can_run_simplified_workflow:
             workflow_type = WorkflowType.SIMPLIFIED
         elif validation.can_run_full_workflow:
@@ -539,7 +534,20 @@ def _execute_simplified_workflow(
             lst_file_path=lst_file,
         )
 
-        final_fit = results_manager.run_results.fit_results[-1]
+        fit_results = results_manager.run_results.fit_results
+        if not fit_results:
+            error_msg = "No fit results found in SAMMY output"
+            logger.error(error_msg)
+            return ResonanceResult(
+                success=False,
+                workflow_type=WorkflowType.SIMPLIFIED,
+                primary_isotope=primary_isotope,
+                error_message=error_msg,
+                error_step="results_parsing",
+                workflow_steps=workflow_steps,
+            )
+
+        final_fit = fit_results[-1]
         chi_sq = final_fit.chi_squared_results
 
         # Extract broadening parameters if available
@@ -549,8 +557,8 @@ def _execute_simplified_workflow(
             broadening = final_fit.physics_data.broadening_parameters
             temperature = float(broadening.temp)
             number_density = float(broadening.thick)
-        except (AttributeError, KeyError):
-            pass
+        except (AttributeError, KeyError) as e:
+            logger.debug(f"Broadening parameters not available: {e}")
 
         workflow_steps["results_parsing"] = "completed"
     except Exception as e:

--- a/src/pleiades/workflows/resonance.py
+++ b/src/pleiades/workflows/resonance.py
@@ -644,7 +644,7 @@ def _execute_simplified_workflow(
     if chi_sq is not None:
         chi_squared_val = float(chi_sq.chi_squared) if chi_sq.chi_squared is not None else None
         reduced_chi_sq_val = float(chi_sq.reduced_chi_squared) if chi_sq.reduced_chi_squared is not None else None
-        dof_val = chi_sq.dof
+        dof_val = chi_sq.dof if chi_sq.dof is not None else None
     fit_quality_val = FitQuality.from_chi_squared(reduced_chi_sq_val) if reduced_chi_sq_val is not None else None
 
     return ResonanceResult(

--- a/src/pleiades/workflows/resonance.py
+++ b/src/pleiades/workflows/resonance.py
@@ -1,0 +1,660 @@
+"""High-level resonance analysis workflows for PLEIADES.
+
+This module provides simple, high-level functions that orchestrate
+complete resonance analysis workflows. These functions can be called
+directly by users or exposed via MCP tools.
+
+Example:
+    >>> from pleiades.workflows import validate_dataset, analyze_resonance
+    >>> result = validate_dataset("/path/to/dataset")
+    >>> if result.valid:
+    ...     analysis = analyze_resonance("/path/to/dataset")
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+from pleiades.utils.logger import loguru_logger
+from pleiades.workflows.models import (
+    FitQuality,
+    ManifestData,
+    MaterialProperties,
+    ResonanceResult,
+    ValidationIssue,
+    ValidationResult,
+    WorkflowType,
+)
+
+if TYPE_CHECKING:
+    from pleiades.sammy.interface import SammyRunner
+
+logger = loguru_logger.bind(name=__name__)
+
+
+def validate_dataset(dataset_path: str | Path) -> ValidationResult:
+    """Validate a dataset for resonance analysis.
+
+    Checks that the dataset has the required structure and files
+    to run resonance analysis. Determines whether the dataset supports
+    the full imaging workflow or simplified SAMMY-only workflow.
+
+    Args:
+        dataset_path: Path to the dataset directory.
+
+    Returns:
+        ValidationResult with validation status and detected capabilities.
+
+    Example:
+        >>> result = validate_dataset("/data/Au197_sample")
+        >>> if result.valid:
+        ...     print(f"Ready for {result.recommended_workflow.value} workflow")
+        >>> else:
+        ...     for error in result.errors:
+        ...         print(f"Error: {error.message}")
+    """
+    dataset_path = Path(dataset_path)
+    issues: list[ValidationIssue] = []
+
+    logger.info(f"Validating dataset: {dataset_path}")
+
+    # Check dataset exists
+    if not dataset_path.exists():
+        return ValidationResult(
+            valid=False,
+            dataset_path=dataset_path,
+            issues=[
+                ValidationIssue(
+                    severity="error",
+                    message=f"Dataset directory does not exist: {dataset_path}",
+                    path=dataset_path,
+                )
+            ],
+        )
+
+    if not dataset_path.is_dir():
+        return ValidationResult(
+            valid=False,
+            dataset_path=dataset_path,
+            issues=[
+                ValidationIssue(
+                    severity="error",
+                    message=f"Path is not a directory: {dataset_path}",
+                    path=dataset_path,
+                )
+            ],
+        )
+
+    # Check for imaging data (full workflow)
+    raw_dir = dataset_path / "raw"
+    ob_dir = dataset_path / "open_beam"
+    metadata_dir = dataset_path / "metadata"
+
+    has_raw = raw_dir.exists() and raw_dir.is_dir()
+    has_ob = ob_dir.exists() and ob_dir.is_dir()
+    has_metadata = metadata_dir.exists() and metadata_dir.is_dir()
+
+    # Check for SAMMY files (simplified workflow)
+    sammy_data_dir = dataset_path / "sammy_data"
+    has_sammy_files = False
+    if sammy_data_dir.exists():
+        inp_files = list(sammy_data_dir.glob("*.inp"))
+        has_sammy_files = len(inp_files) > 0
+
+    # Check for manifest
+    manifest_paths = [
+        dataset_path / "manifest_intermediate.md",
+        dataset_path / "smcp_manifest.md",
+        dataset_path / "manifest.md",
+    ]
+    has_manifest = any(p.exists() for p in manifest_paths)
+
+    # Determine workflow capabilities
+    can_run_full = has_raw and has_ob
+    can_run_simplified = has_sammy_files
+
+    # Build validation issues
+    if not can_run_full and not can_run_simplified:
+        issues.append(
+            ValidationIssue(
+                severity="error",
+                message="Dataset does not contain imaging data (raw/, open_beam/) or SAMMY files (sammy_data/*.inp)",
+                path=dataset_path,
+            )
+        )
+
+    if not has_raw and not has_sammy_files:
+        issues.append(
+            ValidationIssue(
+                severity="error",
+                message="No raw data directory found",
+                path=raw_dir,
+            )
+        )
+
+    if has_raw and not has_ob:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                message="Open beam directory not found - normalization may fail",
+                path=ob_dir,
+            )
+        )
+
+    if has_raw and not has_metadata:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                message="Metadata directory not found - may need manual TOF calibration",
+                path=metadata_dir,
+            )
+        )
+
+    if not has_manifest:
+        issues.append(
+            ValidationIssue(
+                severity="warning",
+                message="No manifest file found - analysis parameters must be provided explicitly",
+                path=dataset_path,
+            )
+        )
+
+    # Validate SAMMY files if present
+    if has_sammy_files:
+        inp_files = list(sammy_data_dir.glob("*.inp"))
+        for inp_file in inp_files:
+            par_file = inp_file.with_suffix(".par")
+            dat_file = inp_file.with_suffix(".dat")
+
+            if not par_file.exists():
+                issues.append(
+                    ValidationIssue(
+                        severity="error",
+                        message=f"Missing parameter file for {inp_file.name}",
+                        path=par_file,
+                    )
+                )
+            if not dat_file.exists():
+                issues.append(
+                    ValidationIssue(
+                        severity="error",
+                        message=f"Missing data file for {inp_file.name}",
+                        path=dat_file,
+                    )
+                )
+
+    # Determine recommended workflow
+    recommended = None
+    if can_run_full:
+        recommended = WorkflowType.FULL
+    elif can_run_simplified:
+        recommended = WorkflowType.SIMPLIFIED
+
+    # Dataset is valid if there are no errors
+    has_errors = any(i.severity == "error" for i in issues)
+
+    result = ValidationResult(
+        valid=not has_errors,
+        dataset_path=dataset_path,
+        can_run_full_workflow=can_run_full,
+        can_run_simplified_workflow=can_run_simplified,
+        recommended_workflow=recommended,
+        has_raw_data=has_raw,
+        has_open_beam=has_ob,
+        has_metadata=has_metadata,
+        has_sammy_files=has_sammy_files,
+        has_manifest=has_manifest,
+        issues=issues,
+    )
+
+    if result.valid:
+        logger.info(f"Dataset valid, recommended workflow: {recommended}")
+    else:
+        logger.warning(f"Dataset validation failed: {len(result.errors)} errors")
+
+    return result
+
+
+def extract_manifest(dataset_path: str | Path) -> ManifestData | None:
+    """Extract and parse manifest from dataset.
+
+    Args:
+        dataset_path: Path to the dataset directory.
+
+    Returns:
+        ManifestData if manifest found and valid, None otherwise.
+
+    Raises:
+        ValueError: If manifest exists but has invalid format.
+    """
+    dataset_path = Path(dataset_path)
+
+    # Try different manifest names
+    manifest_paths = [
+        dataset_path / "manifest_intermediate.md",
+        dataset_path / "smcp_manifest.md",
+        dataset_path / "manifest.md",
+    ]
+
+    manifest_path = None
+    for candidate in manifest_paths:
+        if candidate.exists():
+            manifest_path = candidate
+            break
+
+    if manifest_path is None:
+        logger.debug(f"No manifest found in {dataset_path}")
+        return None
+
+    logger.info(f"Parsing manifest: {manifest_path}")
+
+    with open(manifest_path) as f:
+        content = f.read()
+
+    # Split YAML frontmatter from Markdown body
+    parts = content.split("---")
+    if len(parts) < 3:
+        raise ValueError(f"Invalid manifest format in {manifest_path}: missing YAML frontmatter")
+
+    # Parse YAML frontmatter
+    yaml_content = parts[1].strip()
+    frontmatter = yaml.safe_load(yaml_content)
+
+    # Handle datetime objects (PyYAML auto-parses ISO timestamps)
+    if "created" in frontmatter and hasattr(frontmatter["created"], "isoformat"):
+        frontmatter["created"] = frontmatter["created"].isoformat()
+
+    # Extract markdown body
+    body = parts[2].strip()
+
+    # Parse material properties if present
+    material_props = None
+    if "material_properties" in frontmatter and frontmatter["material_properties"]:
+        mp = frontmatter["material_properties"]
+        material_props = MaterialProperties(
+            density_g_cm3=mp.get("density_g_cm3"),
+            atomic_mass_amu=mp.get("atomic_mass_amu"),
+            temperature_k=mp.get("temperature_k"),
+        )
+
+    return ManifestData(
+        name=frontmatter.get("name", "unknown"),
+        description=frontmatter.get("description", ""),
+        version=frontmatter.get("version", "1.0.0"),
+        created=frontmatter.get("created", ""),
+        facility=frontmatter.get("facility"),
+        beamline=frontmatter.get("beamline"),
+        detector=frontmatter.get("detector"),
+        sample_id=frontmatter.get("sample_id"),
+        isotope=frontmatter.get("isotope"),
+        material_properties=material_props,
+        body=body,
+        raw_frontmatter=frontmatter,
+    )
+
+
+def analyze_resonance(
+    dataset_path: str | Path,
+    *,
+    backend: str = "auto",
+    isotopes: list[str] | None = None,
+    skip_validation: bool = False,
+) -> ResonanceResult:
+    """Execute complete resonance analysis workflow.
+
+    This is the main entry point for resonance analysis. It automatically
+    detects the appropriate workflow (full or simplified) based on the
+    dataset contents and executes all necessary steps.
+
+    Full workflow steps (imaging data):
+        1. Validate dataset structure
+        2. Normalize transmission data
+        3. Convert to SAMMY format
+        4. Retrieve ENDF nuclear parameters
+        5. Execute SAMMY fitting
+        6. Parse and return results
+
+    Simplified workflow steps (pre-existing SAMMY files):
+        1. Validate dataset structure
+        2. Execute SAMMY fitting
+        3. Parse and return results
+
+    Args:
+        dataset_path: Path to the dataset directory.
+        backend: SAMMY backend to use ('local', 'docker', 'nova', or 'auto').
+        isotopes: List of isotopes to analyze. If None, detected from manifest.
+        skip_validation: Skip dataset validation (use with caution).
+
+    Returns:
+        ResonanceResult with analysis results and output paths.
+
+    Raises:
+        ValueError: If dataset is invalid and skip_validation=False.
+
+    Example:
+        >>> result = analyze_resonance("/data/Au197_sample")
+        >>> if result.success:
+        ...     print(f"Reduced chi²: {result.reduced_chi_squared:.3f}")
+        ...     print(f"Fit quality: {result.fit_quality.value}")
+        >>> else:
+        ...     print(f"Analysis failed: {result.error_message}")
+    """
+    import time
+
+    dataset_path = Path(dataset_path)
+    start_time = time.time()
+    workflow_steps: dict[str, str] = {}
+
+    logger.info(f"Starting resonance analysis: {dataset_path}")
+
+    # Step 1: Validate dataset
+    if not skip_validation:
+        workflow_steps["validation"] = "running"
+        validation = validate_dataset(dataset_path)
+
+        if not validation.valid:
+            return ResonanceResult(
+                success=False,
+                workflow_type=WorkflowType.SIMPLIFIED,
+                primary_isotope="unknown",
+                error_message="Dataset validation failed",
+                error_step="validation",
+                workflow_steps={"validation": "failed"},
+            )
+        workflow_steps["validation"] = "completed"
+
+        # Determine workflow type
+        if validation.can_run_simplified_workflow:
+            workflow_type = WorkflowType.SIMPLIFIED
+        elif validation.can_run_full_workflow:
+            workflow_type = WorkflowType.FULL
+        else:
+            return ResonanceResult(
+                success=False,
+                workflow_type=WorkflowType.SIMPLIFIED,
+                primary_isotope="unknown",
+                error_message="No valid workflow detected for dataset",
+                error_step="validation",
+                workflow_steps=workflow_steps,
+            )
+    else:
+        # Assume simplified workflow if skipping validation
+        sammy_data_dir = dataset_path / "sammy_data"
+        if sammy_data_dir.exists() and list(sammy_data_dir.glob("*.inp")):
+            workflow_type = WorkflowType.SIMPLIFIED
+        else:
+            workflow_type = WorkflowType.FULL
+
+    # Extract manifest for parameters
+    manifest = extract_manifest(dataset_path)
+    primary_isotope = "unknown"
+    if manifest and manifest.isotope:
+        primary_isotope = manifest.isotope
+    if isotopes:
+        primary_isotope = isotopes[0]
+
+    # Execute appropriate workflow
+    if workflow_type == WorkflowType.SIMPLIFIED:
+        return _execute_simplified_workflow(
+            dataset_path=dataset_path,
+            primary_isotope=primary_isotope,
+            backend=backend,
+            start_time=start_time,
+            workflow_steps=workflow_steps,
+        )
+    else:
+        return _execute_full_workflow(
+            dataset_path=dataset_path,
+            manifest=manifest,
+            primary_isotope=primary_isotope,
+            isotopes=isotopes,
+            backend=backend,
+            start_time=start_time,
+            workflow_steps=workflow_steps,
+        )
+
+
+def _execute_simplified_workflow(
+    dataset_path: Path,
+    primary_isotope: str,
+    backend: str,
+    start_time: float,
+    workflow_steps: dict[str, str],
+) -> ResonanceResult:
+    """Execute simplified workflow with pre-existing SAMMY files."""
+    import time
+
+    from pleiades.sammy.interface import SammyFiles
+    from pleiades.sammy.results.manager import ResultsManager
+
+    sammy_data_dir = dataset_path / "sammy_data"
+
+    # Find SAMMY input files
+    inp_files = list(sammy_data_dir.glob("*.inp"))
+    if not inp_files:
+        return ResonanceResult(
+            success=False,
+            workflow_type=WorkflowType.SIMPLIFIED,
+            primary_isotope=primary_isotope,
+            error_message=f"No .inp files found in {sammy_data_dir}",
+            error_step="file_discovery",
+            workflow_steps=workflow_steps,
+        )
+
+    inp_file = inp_files[0]
+    par_file = inp_file.with_suffix(".par")
+    dat_file = inp_file.with_suffix(".dat")
+
+    # Validate required files
+    if not par_file.exists():
+        return ResonanceResult(
+            success=False,
+            workflow_type=WorkflowType.SIMPLIFIED,
+            primary_isotope=primary_isotope,
+            error_message=f"Parameter file not found: {par_file}",
+            error_step="file_discovery",
+            workflow_steps=workflow_steps,
+        )
+
+    if not dat_file.exists():
+        return ResonanceResult(
+            success=False,
+            workflow_type=WorkflowType.SIMPLIFIED,
+            primary_isotope=primary_isotope,
+            error_message=f"Data file not found: {dat_file}",
+            error_step="file_discovery",
+            workflow_steps=workflow_steps,
+        )
+
+    logger.info(f"Running simplified workflow with {inp_file.name}")
+
+    # Create working/output directories
+    sammy_working = dataset_path / "sammy_working"
+    sammy_output = dataset_path / "sammy_output"
+    sammy_working.mkdir(exist_ok=True)
+    sammy_output.mkdir(exist_ok=True)
+
+    # Get SAMMY runner
+    workflow_steps["backend_setup"] = "running"
+    try:
+        runner = _get_sammy_runner(backend, sammy_working, sammy_output)
+        workflow_steps["backend_setup"] = "completed"
+    except Exception as e:
+        logger.error(f"Failed to create SAMMY runner: {e}")
+        return ResonanceResult(
+            success=False,
+            workflow_type=WorkflowType.SIMPLIFIED,
+            primary_isotope=primary_isotope,
+            error_message=str(e),
+            error_step="backend_setup",
+            workflow_steps=workflow_steps,
+        )
+
+    # Execute SAMMY
+    workflow_steps["sammy_execution"] = "running"
+    files = SammyFiles(
+        input_file=inp_file,
+        parameter_file=par_file,
+        data_file=dat_file,
+    )
+
+    try:
+        runner.prepare_environment(files)
+        exec_result = runner.execute_sammy(files)
+
+        if not exec_result.success:
+            return ResonanceResult(
+                success=False,
+                workflow_type=WorkflowType.SIMPLIFIED,
+                primary_isotope=primary_isotope,
+                error_message=f"SAMMY execution failed: {exec_result.error_message}",
+                error_step="sammy_execution",
+                workflow_steps=workflow_steps,
+            )
+
+        runner.collect_outputs(exec_result)
+        workflow_steps["sammy_execution"] = "completed"
+    except Exception as e:
+        logger.error(f"SAMMY execution error: {e}")
+        return ResonanceResult(
+            success=False,
+            workflow_type=WorkflowType.SIMPLIFIED,
+            primary_isotope=primary_isotope,
+            error_message=str(e),
+            error_step="sammy_execution",
+            workflow_steps=workflow_steps,
+        )
+
+    # Parse results
+    workflow_steps["results_parsing"] = "running"
+    try:
+        lpt_file = sammy_output / "SAMMY.LPT"
+        lst_file = sammy_output / "SAMMY.LST"
+
+        results_manager = ResultsManager(
+            lpt_file_path=lpt_file,
+            lst_file_path=lst_file,
+        )
+
+        final_fit = results_manager.run_results.fit_results[-1]
+        chi_sq = final_fit.chi_squared_results
+
+        # Extract broadening parameters if available
+        temperature = None
+        number_density = None
+        try:
+            broadening = final_fit.physics_data.broadening_parameters
+            temperature = float(broadening.temp)
+            number_density = float(broadening.thick)
+        except (AttributeError, KeyError):
+            pass
+
+        workflow_steps["results_parsing"] = "completed"
+    except Exception as e:
+        logger.error(f"Results parsing error: {e}")
+        return ResonanceResult(
+            success=False,
+            workflow_type=WorkflowType.SIMPLIFIED,
+            primary_isotope=primary_isotope,
+            error_message=str(e),
+            error_step="results_parsing",
+            workflow_steps=workflow_steps,
+        )
+
+    # Build successful result
+    runtime = time.time() - start_time
+
+    return ResonanceResult(
+        success=True,
+        workflow_type=WorkflowType.SIMPLIFIED,
+        primary_isotope=primary_isotope,
+        isotopes_analyzed=[primary_isotope],
+        chi_squared=float(chi_sq.chi_squared) if chi_sq.chi_squared else None,
+        reduced_chi_squared=float(chi_sq.reduced_chi_squared) if chi_sq.reduced_chi_squared else None,
+        degrees_of_freedom=chi_sq.dof,
+        fit_quality=FitQuality.from_chi_squared(chi_sq.reduced_chi_squared) if chi_sq.reduced_chi_squared else None,
+        number_density=number_density,
+        temperature_k=temperature,
+        output_dir=sammy_output,
+        lpt_file=lpt_file,
+        lst_file=lst_file,
+        par_file=sammy_output / "SAMMY.PAR",
+        runtime_seconds=runtime,
+        workflow_steps=workflow_steps,
+    )
+
+
+def _execute_full_workflow(
+    dataset_path: Path,
+    manifest: ManifestData | None,
+    primary_isotope: str,
+    isotopes: list[str] | None,
+    backend: str,
+    start_time: float,
+    workflow_steps: dict[str, str],
+) -> ResonanceResult:
+    """Execute full workflow from imaging data.
+
+    This is a placeholder for the full imaging workflow.
+    Full implementation will be added when imaging processing
+    infrastructure is ready.
+    """
+    # TODO(#172): Implement full imaging workflow
+    # This requires:
+    # - pleiades.processing.normalization
+    # - pleiades.sammy.io.data_manager (CSV to SAMMY conversion)
+    # - pleiades.sammy.io.json_manager (multi-isotope JSON config)
+    # - pleiades.sammy.io.inp_manager (INP file generation)
+
+    logger.warning("Full imaging workflow not yet implemented")
+
+    return ResonanceResult(
+        success=False,
+        workflow_type=WorkflowType.FULL,
+        primary_isotope=primary_isotope,
+        error_message="Full imaging workflow not yet implemented. Use simplified workflow with pre-existing SAMMY files.",
+        error_step="workflow_selection",
+        workflow_steps=workflow_steps,
+    )
+
+
+def _get_sammy_runner(
+    backend: str,
+    working_dir: Path,
+    output_dir: Path,
+) -> SammyRunner:
+    """Get appropriate SAMMY runner based on backend selection.
+
+    Args:
+        backend: Backend type ('local', 'docker', 'nova', or 'auto').
+        working_dir: SAMMY working directory.
+        output_dir: SAMMY output directory.
+
+    Returns:
+        Configured SammyRunner instance.
+
+    Raises:
+        ValueError: If backend is not available.
+        FileNotFoundError: If local SAMMY executable not found.
+    """
+    from pleiades.sammy.factory import SammyFactory
+
+    working_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if backend == "auto":
+        logger.info("Auto-selecting SAMMY backend")
+        return SammyFactory.auto_select(
+            working_dir=working_dir,
+            output_dir=output_dir,
+        )
+
+    logger.info(f"Creating {backend} SAMMY backend")
+    return SammyFactory.create_runner(
+        backend_type=backend,
+        working_dir=working_dir,
+        output_dir=output_dir,
+    )

--- a/src/pleiades/workflows/resonance.py
+++ b/src/pleiades/workflows/resonance.py
@@ -257,6 +257,10 @@ def extract_manifest(dataset_path: str | Path) -> ManifestData | None:
     yaml_content = parts[1].strip()
     frontmatter = yaml.safe_load(yaml_content)
 
+    # Handle empty frontmatter (yaml.safe_load returns None for empty content)
+    if frontmatter is None:
+        frontmatter = {}
+
     # Handle datetime objects (PyYAML auto-parses ISO timestamps)
     if "created" in frontmatter and hasattr(frontmatter["created"], "isoformat"):
         frontmatter["created"] = frontmatter["created"].isoformat()
@@ -268,11 +272,15 @@ def extract_manifest(dataset_path: str | Path) -> ManifestData | None:
     material_props = None
     if "material_properties" in frontmatter and frontmatter["material_properties"]:
         mp = frontmatter["material_properties"]
-        material_props = MaterialProperties(
-            density_g_cm3=mp.get("density_g_cm3"),
-            atomic_mass_amu=mp.get("atomic_mass_amu"),
-            temperature_k=mp.get("temperature_k"),
-        )
+        try:
+            material_props = MaterialProperties(
+                density_g_cm3=mp.get("density_g_cm3"),
+                atomic_mass_amu=mp.get("atomic_mass_amu"),
+                temperature_k=mp.get("temperature_k"),
+            )
+        except Exception as e:
+            # Log but don't fail - material properties are optional for some workflows
+            logger.warning(f"Invalid material_properties in manifest: {e}")
 
     return ManifestData(
         name=frontmatter.get("name", "unknown"),
@@ -341,6 +349,17 @@ def analyze_resonance(
     start_time = time.time()
     workflow_steps: dict[str, str] = {}
 
+    # Validate isotopes parameter
+    if isotopes is not None and len(isotopes) == 0:
+        return ResonanceResult(
+            success=False,
+            workflow_type=WorkflowType.SIMPLIFIED,
+            primary_isotope="unknown",
+            error_message="isotopes parameter cannot be an empty list",
+            error_step="parameter_validation",
+            workflow_steps={},
+        )
+
     logger.info(f"Starting resonance analysis: {dataset_path}")
 
     # Step 1: Validate dataset
@@ -376,12 +395,29 @@ def analyze_resonance(
                 workflow_steps=workflow_steps,
             )
     else:
-        # Assume simplified workflow if skipping validation
+        # When skipping validation, detect workflow from available files
         sammy_data_dir = dataset_path / "sammy_data"
-        if sammy_data_dir.exists() and list(sammy_data_dir.glob("*.inp")):
+        try:
+            has_sammy_files = sammy_data_dir.exists() and any(sammy_data_dir.glob("*.inp"))
+        except (PermissionError, OSError) as e:
+            logger.warning(f"Cannot access sammy_data directory: {e}")
+            has_sammy_files = False
+        has_imaging_data = (dataset_path / "raw").exists() and (dataset_path / "open_beam").exists()
+
+        if has_sammy_files:
             workflow_type = WorkflowType.SIMPLIFIED
-        else:
+        elif has_imaging_data:
             workflow_type = WorkflowType.FULL
+        else:
+            # Neither workflow is available - return clear error
+            return ResonanceResult(
+                success=False,
+                workflow_type=WorkflowType.SIMPLIFIED,
+                primary_isotope="unknown",
+                error_message="No SAMMY files (sammy_data/*.inp) or imaging data (raw/, open_beam/) found",
+                error_step="file_discovery",
+                workflow_steps=workflow_steps,
+            )
 
     # Extract manifest for parameters
     manifest = extract_manifest(dataset_path)
@@ -529,6 +565,31 @@ def _execute_simplified_workflow(
         lpt_file = sammy_output / "SAMMY.LPT"
         lst_file = sammy_output / "SAMMY.LST"
 
+        # Verify SAMMY produced output files
+        if not lpt_file.exists():
+            error_msg = f"SAMMY output file not found: {lpt_file}"
+            logger.error(error_msg)
+            return ResonanceResult(
+                success=False,
+                workflow_type=WorkflowType.SIMPLIFIED,
+                primary_isotope=primary_isotope,
+                error_message=error_msg,
+                error_step="results_parsing",
+                workflow_steps=workflow_steps,
+            )
+
+        if not lst_file.exists():
+            error_msg = f"SAMMY output file not found: {lst_file}"
+            logger.error(error_msg)
+            return ResonanceResult(
+                success=False,
+                workflow_type=WorkflowType.SIMPLIFIED,
+                primary_isotope=primary_isotope,
+                error_message=error_msg,
+                error_step="results_parsing",
+                workflow_steps=workflow_steps,
+            )
+
         results_manager = ResultsManager(
             lpt_file_path=lpt_file,
             lst_file_path=lst_file,
@@ -557,7 +618,7 @@ def _execute_simplified_workflow(
             broadening = final_fit.physics_data.broadening_parameters
             temperature = float(broadening.temp)
             number_density = float(broadening.thick)
-        except (AttributeError, KeyError) as e:
+        except (AttributeError, KeyError, ValueError, TypeError) as e:
             logger.debug(f"Broadening parameters not available: {e}")
 
         workflow_steps["results_parsing"] = "completed"
@@ -575,15 +636,26 @@ def _execute_simplified_workflow(
     # Build successful result
     runtime = time.time() - start_time
 
+    # Use 'is not None' instead of truthiness check since 0.0 is a valid chi-squared value
+    # Also check chi_sq itself is not None before accessing its attributes
+    chi_squared_val = None
+    reduced_chi_sq_val = None
+    dof_val = None
+    if chi_sq is not None:
+        chi_squared_val = float(chi_sq.chi_squared) if chi_sq.chi_squared is not None else None
+        reduced_chi_sq_val = float(chi_sq.reduced_chi_squared) if chi_sq.reduced_chi_squared is not None else None
+        dof_val = chi_sq.dof
+    fit_quality_val = FitQuality.from_chi_squared(reduced_chi_sq_val) if reduced_chi_sq_val is not None else None
+
     return ResonanceResult(
         success=True,
         workflow_type=WorkflowType.SIMPLIFIED,
         primary_isotope=primary_isotope,
         isotopes_analyzed=[primary_isotope],
-        chi_squared=float(chi_sq.chi_squared) if chi_sq.chi_squared else None,
-        reduced_chi_squared=float(chi_sq.reduced_chi_squared) if chi_sq.reduced_chi_squared else None,
-        degrees_of_freedom=chi_sq.dof,
-        fit_quality=FitQuality.from_chi_squared(chi_sq.reduced_chi_squared) if chi_sq.reduced_chi_squared else None,
+        chi_squared=chi_squared_val,
+        reduced_chi_squared=reduced_chi_sq_val,
+        degrees_of_freedom=dof_val,
+        fit_quality=fit_quality_val,
         number_density=number_density,
         temperature_k=temperature,
         output_dir=sammy_output,

--- a/tests/unit/pleiades/workflows/__init__.py
+++ b/tests/unit/pleiades/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pleiades.workflows module."""

--- a/tests/unit/pleiades/workflows/test_models.py
+++ b/tests/unit/pleiades/workflows/test_models.py
@@ -1,5 +1,6 @@
 """Tests for pleiades.workflows.models module."""
 
+import math
 from pathlib import Path
 
 import pytest
@@ -40,6 +41,21 @@ class TestFitQuality:
         assert FitQuality.from_chi_squared(5.0) == FitQuality.POOR
         assert FitQuality.from_chi_squared(10.0) == FitQuality.POOR
 
+    def test_from_chi_squared_invalid_negative(self):
+        """Negative chi-squared should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid reduced chi-squared"):
+            FitQuality.from_chi_squared(-1.0)
+
+    def test_from_chi_squared_invalid_nan(self):
+        """NaN chi-squared should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid reduced chi-squared"):
+            FitQuality.from_chi_squared(math.nan)
+
+    def test_from_chi_squared_invalid_infinity(self):
+        """Infinite chi-squared should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid reduced chi-squared"):
+            FitQuality.from_chi_squared(math.inf)
+
 
 class TestWorkflowType:
     """Tests for WorkflowType enum."""
@@ -76,6 +92,26 @@ class TestMaterialProperties:
         """Missing required fields should raise ValidationError."""
         with pytest.raises(Exception):  # Pydantic ValidationError
             MaterialProperties(density_g_cm3=19.3)
+
+    def test_negative_density_raises(self):
+        """Negative density should raise ValidationError."""
+        with pytest.raises(Exception, match="must be positive"):
+            MaterialProperties(density_g_cm3=-1.0, atomic_mass_amu=196.97)
+
+    def test_zero_density_raises(self):
+        """Zero density should raise ValidationError."""
+        with pytest.raises(Exception, match="must be positive"):
+            MaterialProperties(density_g_cm3=0.0, atomic_mass_amu=196.97)
+
+    def test_negative_atomic_mass_raises(self):
+        """Negative atomic mass should raise ValidationError."""
+        with pytest.raises(Exception, match="must be positive"):
+            MaterialProperties(density_g_cm3=19.3, atomic_mass_amu=-10.0)
+
+    def test_negative_temperature_raises(self):
+        """Negative temperature should raise ValidationError."""
+        with pytest.raises(Exception, match="must be positive"):
+            MaterialProperties(density_g_cm3=19.3, atomic_mass_amu=196.97, temperature_k=-100.0)
 
 
 class TestValidationIssue:

--- a/tests/unit/pleiades/workflows/test_models.py
+++ b/tests/unit/pleiades/workflows/test_models.py
@@ -1,0 +1,226 @@
+"""Tests for pleiades.workflows.models module."""
+
+from pathlib import Path
+
+import pytest
+
+from pleiades.workflows.models import (
+    FitQuality,
+    ManifestData,
+    MaterialProperties,
+    ResonanceResult,
+    ValidationIssue,
+    ValidationResult,
+    WorkflowType,
+)
+
+
+class TestFitQuality:
+    """Tests for FitQuality enum."""
+
+    def test_from_chi_squared_excellent(self):
+        """Chi² < 1.2 should be excellent."""
+        assert FitQuality.from_chi_squared(0.9) == FitQuality.EXCELLENT
+        assert FitQuality.from_chi_squared(1.1) == FitQuality.EXCELLENT
+
+    def test_from_chi_squared_good(self):
+        """1.2 <= Chi² < 2.0 should be good."""
+        assert FitQuality.from_chi_squared(1.2) == FitQuality.GOOD
+        assert FitQuality.from_chi_squared(1.5) == FitQuality.GOOD
+        assert FitQuality.from_chi_squared(1.99) == FitQuality.GOOD
+
+    def test_from_chi_squared_acceptable(self):
+        """2.0 <= Chi² < 5.0 should be acceptable."""
+        assert FitQuality.from_chi_squared(2.0) == FitQuality.ACCEPTABLE
+        assert FitQuality.from_chi_squared(3.5) == FitQuality.ACCEPTABLE
+        assert FitQuality.from_chi_squared(4.99) == FitQuality.ACCEPTABLE
+
+    def test_from_chi_squared_poor(self):
+        """Chi² >= 5.0 should be poor."""
+        assert FitQuality.from_chi_squared(5.0) == FitQuality.POOR
+        assert FitQuality.from_chi_squared(10.0) == FitQuality.POOR
+
+
+class TestWorkflowType:
+    """Tests for WorkflowType enum."""
+
+    def test_workflow_type_values(self):
+        """WorkflowType should have expected values."""
+        assert WorkflowType.FULL.value == "full"
+        assert WorkflowType.SIMPLIFIED.value == "simplified"
+
+
+class TestMaterialProperties:
+    """Tests for MaterialProperties model."""
+
+    def test_create_with_required_fields(self):
+        """MaterialProperties should require density and atomic mass."""
+        mp = MaterialProperties(
+            density_g_cm3=19.3,
+            atomic_mass_amu=196.97,
+        )
+        assert mp.density_g_cm3 == 19.3
+        assert mp.atomic_mass_amu == 196.97
+        assert mp.temperature_k is None
+
+    def test_create_with_all_fields(self):
+        """MaterialProperties should accept optional temperature."""
+        mp = MaterialProperties(
+            density_g_cm3=19.3,
+            atomic_mass_amu=196.97,
+            temperature_k=293.6,
+        )
+        assert mp.temperature_k == 293.6
+
+    def test_missing_required_field_raises(self):
+        """Missing required fields should raise ValidationError."""
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            MaterialProperties(density_g_cm3=19.3)
+
+
+class TestValidationIssue:
+    """Tests for ValidationIssue model."""
+
+    def test_create_error(self):
+        """ValidationIssue should accept error severity."""
+        issue = ValidationIssue(
+            severity="error",
+            message="Missing raw data directory",
+            path=Path("/data/raw"),
+        )
+        assert issue.severity == "error"
+        assert "raw data" in issue.message
+        assert issue.path == Path("/data/raw")
+
+    def test_create_warning(self):
+        """ValidationIssue should accept warning severity."""
+        issue = ValidationIssue(
+            severity="warning",
+            message="Open beam directory not found",
+        )
+        assert issue.severity == "warning"
+        assert issue.path is None
+
+
+class TestValidationResult:
+    """Tests for ValidationResult model."""
+
+    def test_valid_dataset(self):
+        """ValidationResult for valid dataset."""
+        result = ValidationResult(
+            valid=True,
+            dataset_path=Path("/data/sample"),
+            can_run_simplified_workflow=True,
+            recommended_workflow=WorkflowType.SIMPLIFIED,
+            has_sammy_files=True,
+        )
+        assert result.valid
+        assert result.can_run_simplified_workflow
+        assert result.recommended_workflow == WorkflowType.SIMPLIFIED
+
+    def test_invalid_dataset_with_errors(self):
+        """ValidationResult should track errors."""
+        result = ValidationResult(
+            valid=False,
+            dataset_path=Path("/data/sample"),
+            issues=[
+                ValidationIssue(severity="error", message="No data found"),
+                ValidationIssue(severity="warning", message="Missing metadata"),
+            ],
+        )
+        assert not result.valid
+        assert len(result.errors) == 1
+        assert len(result.warnings) == 1
+
+    def test_errors_property(self):
+        """errors property should filter to error-level issues."""
+        result = ValidationResult(
+            valid=False,
+            dataset_path=Path("/data/sample"),
+            issues=[
+                ValidationIssue(severity="error", message="Error 1"),
+                ValidationIssue(severity="error", message="Error 2"),
+                ValidationIssue(severity="warning", message="Warning 1"),
+            ],
+        )
+        assert len(result.errors) == 2
+        assert len(result.warnings) == 1
+
+
+class TestResonanceResult:
+    """Tests for ResonanceResult model."""
+
+    def test_successful_result(self):
+        """ResonanceResult for successful analysis."""
+        result = ResonanceResult(
+            success=True,
+            workflow_type=WorkflowType.SIMPLIFIED,
+            primary_isotope="Au-197",
+            isotopes_analyzed=["Au-197"],
+            chi_squared=125.5,
+            reduced_chi_squared=1.05,
+            degrees_of_freedom=120,
+            fit_quality=FitQuality.EXCELLENT,
+            number_density=0.00123,
+            temperature_k=293.6,
+            output_dir=Path("/data/output"),
+            lpt_file=Path("/data/output/SAMMY.LPT"),
+            lst_file=Path("/data/output/SAMMY.LST"),
+            runtime_seconds=5.2,
+        )
+        assert result.success
+        assert result.primary_isotope == "Au-197"
+        assert result.fit_quality == FitQuality.EXCELLENT
+        assert result.error_message is None
+
+    def test_failed_result(self):
+        """ResonanceResult for failed analysis."""
+        result = ResonanceResult(
+            success=False,
+            workflow_type=WorkflowType.SIMPLIFIED,
+            primary_isotope="Au-197",
+            error_message="SAMMY execution failed",
+            error_step="sammy_execution",
+        )
+        assert not result.success
+        assert result.error_message == "SAMMY execution failed"
+        assert result.error_step == "sammy_execution"
+        assert result.reduced_chi_squared is None
+
+
+class TestManifestData:
+    """Tests for ManifestData model."""
+
+    def test_create_minimal(self):
+        """ManifestData with only required fields."""
+        manifest = ManifestData(
+            name="test_dataset",
+            description="Test dataset for unit tests",
+            version="1.0.0",
+            created="2024-01-01T00:00:00Z",
+        )
+        assert manifest.name == "test_dataset"
+        assert manifest.isotope is None
+        assert manifest.material_properties is None
+
+    def test_create_full(self):
+        """ManifestData with all fields."""
+        manifest = ManifestData(
+            name="Au197_sample",
+            description="Gold-197 calibration sample",
+            version="1.0.0",
+            created="2024-01-01T00:00:00Z",
+            facility="SNS",
+            beamline="VENUS",
+            detector="MCP",
+            sample_id="Au197-001",
+            isotope="Au-197",
+            material_properties=MaterialProperties(
+                density_g_cm3=19.3,
+                atomic_mass_amu=196.97,
+            ),
+            body="# Analysis Instructions\n\nRun fitting with default parameters.",
+        )
+        assert manifest.isotope == "Au-197"
+        assert manifest.material_properties.density_g_cm3 == 19.3
+        assert "Analysis Instructions" in manifest.body

--- a/tests/unit/pleiades/workflows/test_resonance.py
+++ b/tests/unit/pleiades/workflows/test_resonance.py
@@ -1,0 +1,320 @@
+"""Tests for pleiades.workflows.resonance module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pleiades.workflows.models import WorkflowType
+from pleiades.workflows.resonance import (
+    extract_manifest,
+    validate_dataset,
+)
+
+
+class TestValidateDataset:
+    """Tests for validate_dataset function."""
+
+    def test_nonexistent_path(self, tmp_path):
+        """Validation should fail for nonexistent path."""
+        result = validate_dataset(tmp_path / "nonexistent")
+        assert not result.valid
+        assert len(result.errors) == 1
+        assert "does not exist" in result.errors[0].message
+
+    def test_file_not_directory(self, tmp_path):
+        """Validation should fail if path is a file."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        result = validate_dataset(test_file)
+        assert not result.valid
+        assert "not a directory" in result.errors[0].message
+
+    def test_empty_directory(self, tmp_path):
+        """Validation should fail for empty directory."""
+        result = validate_dataset(tmp_path)
+        assert not result.valid
+        assert not result.can_run_full_workflow
+        assert not result.can_run_simplified_workflow
+
+    def test_simplified_workflow_valid(self, tmp_path):
+        """Dataset with SAMMY files should support simplified workflow."""
+        sammy_dir = tmp_path / "sammy_data"
+        sammy_dir.mkdir()
+
+        # Create SAMMY input files
+        (sammy_dir / "ex012a.inp").write_text("SAMMY input")
+        (sammy_dir / "ex012a.par").write_text("SAMMY params")
+        (sammy_dir / "ex012a.dat").write_text("SAMMY data")
+
+        result = validate_dataset(tmp_path)
+        assert result.valid
+        assert result.can_run_simplified_workflow
+        assert not result.can_run_full_workflow
+        assert result.recommended_workflow == WorkflowType.SIMPLIFIED
+        assert result.has_sammy_files
+
+    def test_simplified_workflow_missing_par(self, tmp_path):
+        """Missing .par file should be an error."""
+        sammy_dir = tmp_path / "sammy_data"
+        sammy_dir.mkdir()
+
+        (sammy_dir / "ex012a.inp").write_text("SAMMY input")
+        (sammy_dir / "ex012a.dat").write_text("SAMMY data")
+
+        result = validate_dataset(tmp_path)
+        assert not result.valid
+        assert any("Missing parameter file" in e.message for e in result.errors)
+
+    def test_full_workflow_valid(self, tmp_path):
+        """Dataset with imaging data should support full workflow."""
+        (tmp_path / "raw").mkdir()
+        (tmp_path / "open_beam").mkdir()
+
+        result = validate_dataset(tmp_path)
+        assert result.valid
+        assert result.can_run_full_workflow
+        assert not result.can_run_simplified_workflow
+        assert result.recommended_workflow == WorkflowType.FULL
+        assert result.has_raw_data
+        assert result.has_open_beam
+
+    def test_full_workflow_missing_open_beam(self, tmp_path):
+        """Missing open_beam should be a warning."""
+        (tmp_path / "raw").mkdir()
+
+        result = validate_dataset(tmp_path)
+        # Still valid but with warning
+        assert result.has_raw_data
+        assert not result.has_open_beam
+        assert any("Open beam directory" in w.message for w in result.warnings)
+
+    def test_manifest_detection(self, tmp_path):
+        """Manifest file should be detected."""
+        (tmp_path / "sammy_data").mkdir()
+        (tmp_path / "sammy_data" / "test.inp").write_text("input")
+        (tmp_path / "sammy_data" / "test.par").write_text("params")
+        (tmp_path / "sammy_data" / "test.dat").write_text("data")
+
+        # Create manifest
+        manifest_content = """---
+name: test_dataset
+description: Test
+tool: pleiades
+physics: nri
+version: "1.0.0"
+created: "2024-01-01T00:00:00Z"
+---
+# Instructions
+"""
+        (tmp_path / "manifest_intermediate.md").write_text(manifest_content)
+
+        result = validate_dataset(tmp_path)
+        assert result.valid
+        assert result.has_manifest
+
+
+class TestExtractManifest:
+    """Tests for extract_manifest function."""
+
+    def test_no_manifest(self, tmp_path):
+        """Should return None if no manifest found."""
+        result = extract_manifest(tmp_path)
+        assert result is None
+
+    def test_valid_manifest(self, tmp_path):
+        """Should parse valid manifest."""
+        manifest_content = """---
+name: Au197_sample
+description: Gold calibration sample
+tool: pleiades
+physics: nri
+version: "1.0.0"
+created: "2024-01-01T00:00:00Z"
+facility: SNS
+beamline: VENUS
+isotope: Au-197
+---
+# Analysis Instructions
+
+Run with default parameters.
+"""
+        (tmp_path / "manifest_intermediate.md").write_text(manifest_content)
+
+        result = extract_manifest(tmp_path)
+        assert result is not None
+        assert result.name == "Au197_sample"
+        assert result.isotope == "Au-197"
+        assert result.facility == "SNS"
+        assert "Analysis Instructions" in result.body
+
+    def test_manifest_with_material_properties(self, tmp_path):
+        """Should parse material_properties from manifest."""
+        manifest_content = """---
+name: test
+description: Test
+tool: pleiades
+physics: nri
+version: "1.0.0"
+created: "2024-01-01T00:00:00Z"
+material_properties:
+  density_g_cm3: 19.3
+  atomic_mass_amu: 196.97
+  temperature_k: 293.6
+---
+Body content
+"""
+        (tmp_path / "manifest_intermediate.md").write_text(manifest_content)
+
+        result = extract_manifest(tmp_path)
+        assert result is not None
+        assert result.material_properties is not None
+        assert result.material_properties.density_g_cm3 == 19.3
+        assert result.material_properties.atomic_mass_amu == 196.97
+        assert result.material_properties.temperature_k == 293.6
+
+    def test_invalid_manifest_format(self, tmp_path):
+        """Should raise ValueError for invalid format."""
+        (tmp_path / "manifest_intermediate.md").write_text("No frontmatter here")
+
+        with pytest.raises(ValueError, match="missing YAML frontmatter"):
+            extract_manifest(tmp_path)
+
+    def test_alternate_manifest_names(self, tmp_path):
+        """Should find manifest with alternate names."""
+        manifest_content = """---
+name: test
+description: Test
+tool: pleiades
+physics: nri
+version: "1.0.0"
+created: "2024-01-01T00:00:00Z"
+---
+Body
+"""
+        # Test smcp_manifest.md
+        (tmp_path / "smcp_manifest.md").write_text(manifest_content)
+
+        result = extract_manifest(tmp_path)
+        assert result is not None
+        assert result.name == "test"
+
+
+class TestAnalyzeResonance:
+    """Tests for analyze_resonance function."""
+
+    def test_invalid_dataset_fails(self, tmp_path):
+        """Analysis should fail for invalid dataset."""
+        from pleiades.workflows.resonance import analyze_resonance
+
+        result = analyze_resonance(tmp_path / "nonexistent")
+        assert not result.success
+        assert result.error_step == "validation"
+
+    def test_skip_validation(self, tmp_path):
+        """skip_validation should bypass validation check."""
+        from pleiades.workflows.resonance import analyze_resonance
+
+        # Empty directory, would fail validation
+        result = analyze_resonance(tmp_path, skip_validation=True)
+        # Should fail at file discovery, not validation
+        assert not result.success
+        assert result.error_step != "validation"
+
+    @patch("pleiades.sammy.results.manager.ResultsManager")
+    @patch("pleiades.sammy.factory.SammyFactory")
+    def test_simplified_workflow_success(self, mock_factory, mock_results_manager_class, tmp_path):
+        """Simplified workflow should succeed with mocked SAMMY."""
+        from pleiades.workflows.resonance import analyze_resonance
+
+        # Create SAMMY files
+        sammy_dir = tmp_path / "sammy_data"
+        sammy_dir.mkdir()
+        (sammy_dir / "ex012a.inp").write_text("input")
+        (sammy_dir / "ex012a.par").write_text("params")
+        (sammy_dir / "ex012a.dat").write_text("data")
+
+        # Mock SAMMY runner
+        mock_runner = MagicMock()
+        mock_exec_result = MagicMock()
+        mock_exec_result.success = True
+        mock_runner.execute_sammy.return_value = mock_exec_result
+        mock_factory.auto_select.return_value = mock_runner
+
+        # Mock results manager
+        mock_fit_result = MagicMock()
+        mock_fit_result.chi_squared_results.chi_squared = 125.5
+        mock_fit_result.chi_squared_results.reduced_chi_squared = 1.05
+        mock_fit_result.chi_squared_results.dof = 120
+        mock_fit_result.physics_data.broadening_parameters.temp = 293.6
+        mock_fit_result.physics_data.broadening_parameters.thick = 0.00123
+
+        mock_run_results = MagicMock()
+        mock_run_results.fit_results = [mock_fit_result]
+        mock_results_manager_class.return_value.run_results = mock_run_results
+
+        result = analyze_resonance(tmp_path)
+
+        assert result.success
+        assert result.workflow_type == WorkflowType.SIMPLIFIED
+        assert result.reduced_chi_squared == 1.05
+        assert result.temperature_k == 293.6
+
+    def test_full_workflow_not_implemented(self, tmp_path):
+        """Full workflow should return not-implemented error."""
+        from pleiades.workflows.resonance import analyze_resonance
+
+        # Create imaging data structure
+        (tmp_path / "raw").mkdir()
+        (tmp_path / "open_beam").mkdir()
+
+        result = analyze_resonance(tmp_path)
+
+        assert not result.success
+        assert result.workflow_type == WorkflowType.FULL
+        assert "not yet implemented" in result.error_message
+
+
+class TestGetSammyRunner:
+    """Tests for _get_sammy_runner helper."""
+
+    @patch("pleiades.sammy.factory.SammyFactory")
+    def test_auto_backend(self, mock_factory, tmp_path):
+        """auto backend should call SammyFactory.auto_select."""
+        from pleiades.workflows.resonance import _get_sammy_runner
+
+        working = tmp_path / "work"
+        output = tmp_path / "output"
+
+        _get_sammy_runner("auto", working, output)
+
+        mock_factory.auto_select.assert_called_once()
+
+    @patch("pleiades.sammy.factory.SammyFactory")
+    def test_specific_backend(self, mock_factory, tmp_path):
+        """Specific backend should call SammyFactory.create_runner."""
+        from pleiades.workflows.resonance import _get_sammy_runner
+
+        working = tmp_path / "work"
+        output = tmp_path / "output"
+
+        _get_sammy_runner("docker", working, output)
+
+        mock_factory.create_runner.assert_called_once_with(
+            backend_type="docker",
+            working_dir=working,
+            output_dir=output,
+        )
+
+    @patch("pleiades.sammy.factory.SammyFactory")
+    def test_creates_directories(self, mock_factory, tmp_path):
+        """Should create working and output directories."""
+        from pleiades.workflows.resonance import _get_sammy_runner
+
+        working = tmp_path / "work"
+        output = tmp_path / "output"
+
+        _get_sammy_runner("auto", working, output)
+
+        assert working.exists()
+        assert output.exists()

--- a/tests/unit/pleiades/workflows/test_resonance.py
+++ b/tests/unit/pleiades/workflows/test_resonance.py
@@ -80,13 +80,17 @@ class TestValidateDataset:
         assert result.has_open_beam
 
     def test_full_workflow_missing_open_beam(self, tmp_path):
-        """Missing open_beam should be a warning."""
+        """Missing open_beam makes full workflow unavailable (invalid dataset)."""
         (tmp_path / "raw").mkdir()
 
         result = validate_dataset(tmp_path)
-        # Still valid but with warning
+        # Dataset is invalid because full workflow needs both raw and open_beam
+        # and no simplified workflow is available either
+        assert not result.valid
         assert result.has_raw_data
         assert not result.has_open_beam
+        assert not result.can_run_full_workflow
+        # Should have warning about missing open_beam
         assert any("Open beam directory" in w.message for w in result.warnings)
 
     def test_manifest_detection(self, tmp_path):
@@ -112,6 +116,26 @@ created: "2024-01-01T00:00:00Z"
         result = validate_dataset(tmp_path)
         assert result.valid
         assert result.has_manifest
+
+    def test_both_workflow_types_available(self, tmp_path):
+        """Dataset with both imaging data and SAMMY files should prefer simplified."""
+        # Create imaging data
+        (tmp_path / "raw").mkdir()
+        (tmp_path / "open_beam").mkdir()
+
+        # Create SAMMY files
+        sammy_dir = tmp_path / "sammy_data"
+        sammy_dir.mkdir()
+        (sammy_dir / "test.inp").write_text("input")
+        (sammy_dir / "test.par").write_text("params")
+        (sammy_dir / "test.dat").write_text("data")
+
+        result = validate_dataset(tmp_path)
+        assert result.valid
+        assert result.can_run_full_workflow
+        assert result.can_run_simplified_workflow
+        # Should prefer simplified since full is not yet implemented
+        assert result.recommended_workflow == WorkflowType.SIMPLIFIED
 
 
 class TestExtractManifest:
@@ -199,6 +223,41 @@ Body
         assert result is not None
         assert result.name == "test"
 
+    def test_manifest_with_horizontal_rule_in_body(self, tmp_path):
+        """Should handle markdown body containing --- (horizontal rule)."""
+        manifest_content = """---
+name: test
+description: Test with horizontal rule
+tool: pleiades
+physics: nri
+version: "1.0.0"
+created: "2024-01-01T00:00:00Z"
+---
+# Section 1
+
+Some content here.
+
+---
+
+# Section 2
+
+More content after horizontal rule.
+
+---
+
+Final section.
+"""
+        (tmp_path / "manifest_intermediate.md").write_text(manifest_content)
+
+        result = extract_manifest(tmp_path)
+        assert result is not None
+        assert result.name == "test"
+        # Body should contain the horizontal rules
+        assert "---" in result.body
+        assert "Section 1" in result.body
+        assert "Section 2" in result.body
+        assert "Final section" in result.body
+
 
 class TestAnalyzeResonance:
     """Tests for analyze_resonance function."""
@@ -273,6 +332,38 @@ class TestAnalyzeResonance:
         assert not result.success
         assert result.workflow_type == WorkflowType.FULL
         assert "not yet implemented" in result.error_message
+
+    @patch("pleiades.sammy.results.manager.ResultsManager")
+    @patch("pleiades.sammy.factory.SammyFactory")
+    def test_empty_fit_results_handled(self, mock_factory, mock_results_manager_class, tmp_path):
+        """Empty fit_results list should return error, not crash."""
+        from pleiades.workflows.resonance import analyze_resonance
+
+        # Create SAMMY files
+        sammy_dir = tmp_path / "sammy_data"
+        sammy_dir.mkdir()
+        (sammy_dir / "ex012a.inp").write_text("input")
+        (sammy_dir / "ex012a.par").write_text("params")
+        (sammy_dir / "ex012a.dat").write_text("data")
+
+        # Mock SAMMY runner
+        mock_runner = MagicMock()
+        mock_exec_result = MagicMock()
+        mock_exec_result.success = True
+        mock_runner.execute_sammy.return_value = mock_exec_result
+        mock_factory.auto_select.return_value = mock_runner
+
+        # Mock results manager with EMPTY fit_results
+        mock_run_results = MagicMock()
+        mock_run_results.fit_results = []  # Empty list
+        mock_results_manager_class.return_value.run_results = mock_run_results
+
+        result = analyze_resonance(tmp_path)
+
+        # Should fail gracefully, not crash with IndexError
+        assert not result.success
+        assert result.error_step == "results_parsing"
+        assert "No fit results" in result.error_message
 
 
 class TestGetSammyRunner:

--- a/tests/unit/pleiades/workflows/test_resonance.py
+++ b/tests/unit/pleiades/workflows/test_resonance.py
@@ -278,7 +278,8 @@ class TestAnalyzeResonance:
         result = analyze_resonance(tmp_path, skip_validation=True)
         # Should fail at file discovery, not validation
         assert not result.success
-        assert result.error_step != "validation"
+        assert result.error_step == "file_discovery"
+        assert "No SAMMY files" in result.error_message
 
     @patch("pleiades.sammy.results.manager.ResultsManager")
     @patch("pleiades.sammy.factory.SammyFactory")
@@ -292,6 +293,12 @@ class TestAnalyzeResonance:
         (sammy_dir / "ex012a.inp").write_text("input")
         (sammy_dir / "ex012a.par").write_text("params")
         (sammy_dir / "ex012a.dat").write_text("data")
+
+        # Create expected SAMMY output files (these are checked before parsing)
+        sammy_output = tmp_path / "sammy_output"
+        sammy_output.mkdir()
+        (sammy_output / "SAMMY.LPT").write_text("log output")
+        (sammy_output / "SAMMY.LST").write_text("list output")
 
         # Mock SAMMY runner
         mock_runner = MagicMock()
@@ -345,6 +352,12 @@ class TestAnalyzeResonance:
         (sammy_dir / "ex012a.inp").write_text("input")
         (sammy_dir / "ex012a.par").write_text("params")
         (sammy_dir / "ex012a.dat").write_text("data")
+
+        # Create expected SAMMY output files (these are checked before parsing)
+        sammy_output = tmp_path / "sammy_output"
+        sammy_output.mkdir()
+        (sammy_output / "SAMMY.LPT").write_text("log output")
+        (sammy_output / "SAMMY.LST").write_text("list output")
 
         # Mock SAMMY runner
         mock_runner = MagicMock()


### PR DESCRIPTION
## Summary

Implements #164 - Create pleiades.workflows module with high-level APIs.

This PR introduces a new `pleiades.workflows` module that provides simple, high-level functions for common PLEIADES operations. These functions orchestrate multiple lower-level APIs to perform complete analysis workflows.

### Key Functions

- **`validate_dataset(path)`** - Check dataset structure and determine workflow type (simplified vs full)
- **`analyze_resonance(path)`** - Execute complete resonance analysis workflow  
- **`extract_manifest(path)`** - Parse sMCP manifest files from datasets

### Features

- Supports both workflow types:
  - **Simplified**: Pre-existing SAMMY files (`.inp`, `.par`, `.dat`)
  - **Full**: Raw imaging data → normalization → SAMMY (placeholder, see #172)
- Pydantic models for type-safe results (`ResonanceResult`, `ValidationResult`)
- Follows existing PLEIADES patterns (factory, logging, error handling)
- 37 comprehensive tests with full mock coverage

### Usage Example

```python
from pleiades.workflows import validate_dataset, analyze_resonance

# Validate dataset
result = validate_dataset("/path/to/dataset")
if result.valid:
    print(f"Ready for {result.recommended_workflow.value} workflow")

# Run analysis
analysis = analyze_resonance("/path/to/dataset")
if analysis.success:
    print(f"Chi²/dof: {analysis.reduced_chi_squared:.3f}")
    print(f"Fit quality: {analysis.fit_quality.value}")
```

### Files Added

- `src/pleiades/workflows/__init__.py` - Module exports
- `src/pleiades/workflows/models.py` - Pydantic result models
- `src/pleiades/workflows/resonance.py` - Workflow implementations
- `tests/unit/pleiades/workflows/` - Test suite (37 tests)

## Test plan

- [x] All 37 new workflow tests pass
- [x] Full unit test suite passes (1072 tests)
- [x] No lint errors in new code
- [x] No Pydantic deprecation warnings

## Related Issues

- Part of Epic #163 (MCP Server Integration)
- Blocks #166 (MCP tool decorators), #168 (MCP prototype migration)
- Full workflow implementation deferred to #172 (2D imaging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)