### PR TITLE
docs(mcp): add MCP module documentation

### DIFF
--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -1,0 +1,318 @@
+# PLEIADES MCP Server
+
+PLEIADES provides an optional MCP (Model Context Protocol) server that enables AI-assisted neutron resonance analysis. The MCP server exposes PLEIADES workflow functions as tools that AI applications (Claude Code, Claude Desktop, Cursor, etc.) can invoke.
+
+> **Note**: MCP support is available in PLEIADES v2.2.0+
+
+## What is MCP?
+
+[Model Context Protocol](https://modelcontextprotocol.io/) is an open standard for connecting AI applications to external systems. It provides a standardized way for AI models to access data sources, use tools, and execute workflows. Think of it as "USB-C for AI applications."
+
+## Installation
+
+### From PyPI
+
+```bash
+pip install pleiades-neutron[mcp]
+```
+
+### Editable Install (Development)
+
+```bash
+git clone https://github.com/lanl/PLEIADES.git
+cd PLEIADES
+pip install -e ".[mcp]"
+```
+
+### Using Pixi
+
+```bash
+pixi install -e mcp
+pixi run mcp-server
+```
+
+## Quick Start
+
+### 1. Start the MCP Server
+
+```bash
+# Using console script
+pleiades-mcp
+
+# Or using module invocation
+python -m pleiades.mcp
+```
+
+### 2. Register with Claude Code
+
+Create a `.mcp.json` file in your project directory:
+
+```json
+{
+  "mcpServers": {
+    "pleiades": {
+      "command": "pleiades-mcp"
+    }
+  }
+}
+```
+
+For Pixi-based projects:
+
+```json
+{
+  "mcpServers": {
+    "pleiades": {
+      "command": "pixi",
+      "args": ["run", "mcp-server"]
+    }
+  }
+}
+```
+
+### 3. Use with Claude Code
+
+Once registered, Claude Code will automatically connect to the PLEIADES MCP server. You can then make natural language requests:
+
+- "Validate the dataset at ./datasets/hafnium"
+- "Extract the manifest from this resonance data"
+- "Analyze the neutron resonance data using the Docker backend"
+
+## Workflow Overview
+
+The MCP tools orchestrate the following workflow:
+
+```mermaid
+flowchart TD
+    A[Validate Dataset] --> B[Extract Manifest]
+    B --> C{Detect Workflow Type}
+    C -->|raw + open_beam| D[Full Workflow]
+    C -->|sammy_data only| E[Simplified Workflow]
+    D --> F[Normalize Data]
+    F --> G[Run SAMMY]
+    E --> G
+    G --> H[Parse Results]
+    H --> I["chi², fit quality, isotope abundances"]
+```
+
+## Available Tools
+
+### `validate_resonance_dataset`
+
+Validate a neutron resonance dataset structure and check readiness for analysis.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `dataset_path` | string | Yes | Path to the dataset directory |
+
+**Returns:** Validation result with:
+- `valid`: Overall validity status
+- `can_run_full_workflow`: Whether full imaging workflow is available
+- `can_run_simplified_workflow`: Whether SAMMY-only workflow is available
+- `recommended_workflow`: `"full"`, `"simplified"`, or `None`
+- `issues`: List of validation issues with severity and messages
+
+### `extract_resonance_manifest`
+
+Extract and parse the manifest from a neutron resonance dataset.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `dataset_path` | string | Yes | Path to the dataset directory |
+
+**Manifest file search order:**
+1. `manifest_intermediate.md`
+2. `smcp_manifest.md`
+3. `manifest.md`
+
+**Returns:** Manifest data including:
+- `name`, `description`, `version`: Basic metadata
+- `facility`, `beamline`, `detector`: Experiment info
+- `isotope`: Primary isotope (e.g., "Hf-177")
+- `isotopes`: Explicit isotope list (takes priority over natural abundance)
+- `material_properties`: Density, atomic mass, temperature
+
+See [Manifest Format](manifest-format.md) for complete specification.
+
+### `analyze_resonance`
+
+Perform neutron resonance analysis on a dataset using SAMMY.
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `dataset_path` | string | Yes | - | Path to the dataset directory |
+| `backend` | string | No | `"auto"` | SAMMY backend: `"auto"`, `"local"`, or `"docker"` |
+| `isotopes` | list[str] | No | `None` | Specific isotopes to analyze (e.g., `["Hf-177", "Hf-178"]`) |
+
+**Isotope Selection Priority:**
+
+When determining which isotopes to analyze, PLEIADES uses this priority order:
+
+1. **`isotopes` parameter** (highest priority) - If you pass isotopes to the function
+2. **Manifest `isotopes` field** - Explicit list in the manifest file
+3. **Manifest `enrichment` field** - Custom isotope composition (when `use_natural_abundance: false`)
+4. **Natural abundance lookup** (default) - Uses PLEIADES isotope database
+
+**Returns:** Analysis result with:
+- `success`: Whether analysis completed
+- `workflow_type`: `"simplified"` or `"full"`
+- `chi_squared`, `reduced_chi_squared`: Fit quality metrics
+- `fit_quality`: `"excellent"`, `"good"`, `"acceptable"`, or `"poor"`
+- `isotope_results`: Per-isotope abundances and uncertainties
+- `output_dir`, `lpt_file`, `lst_file`: Output file paths
+
+## Output Format
+
+All tools return JSON-serializable dictionaries with a consistent format:
+
+**Success:**
+```json
+{
+  "status": "success",
+  "data": {
+    "valid": true,
+    "recommended_workflow": "simplified",
+    ...
+  }
+}
+```
+
+**Error:**
+```json
+{
+  "status": "error",
+  "error": "Dataset validation failed: missing sammy_data/ directory"
+}
+```
+
+**Common error messages:**
+- `"No manifest found in /path (searched: manifest_intermediate.md, smcp_manifest.md, manifest.md)"`
+- `"Dataset validation failed: ..."`
+- `"SAMMY execution failed: ..."`
+- `"No SAMMY backend available"`
+- `"ENDF parameter file not found for isotope: Hf-999"`
+
+## Backend Options
+
+The `analyze_resonance` tool supports multiple SAMMY execution backends:
+
+| Backend | Description | Requirements |
+|---------|-------------|--------------|
+| `auto` | Auto-detect best available (tries Docker first, then local) | Any of the below |
+| `local` | Run SAMMY binary directly | SAMMY installed locally |
+| `docker` | Run SAMMY in Docker container | Docker installed and running |
+
+> **Note**: The `nova` backend (ORNL NOVA service) is currently disabled due to package instability.
+
+## Programmatic Usage
+
+You can also use the MCP tools directly in Python without the server:
+
+```python
+from pleiades.mcp.tools import (
+    validate_resonance_dataset,
+    extract_resonance_manifest,
+    analyze_resonance,
+)
+
+# Validate a dataset
+result = validate_resonance_dataset("/path/to/dataset")
+if result["status"] == "success":
+    data = result["data"]
+    print(f"Valid: {data['valid']}")
+    print(f"Recommended workflow: {data['recommended_workflow']}")
+    for issue in data.get("issues", []):
+        print(f"  [{issue['severity']}] {issue['message']}")
+else:
+    print(f"Validation error: {result['error']}")
+
+# Extract manifest
+manifest = extract_resonance_manifest("/path/to/dataset")
+if manifest["status"] == "success":
+    data = manifest["data"]
+    print(f"Isotope: {data['isotope']}")
+    print(f"Isotopes list: {data.get('isotopes')}")  # May be None
+
+# Run analysis
+analysis = analyze_resonance(
+    "/path/to/dataset",
+    backend="docker",
+    isotopes=["Hf-177", "Hf-178"]
+)
+if analysis["status"] == "success":
+    data = analysis["data"]
+    print(f"Success: {data['success']}")
+    print(f"Chi-squared: {data['chi_squared']}")
+    print(f"Fit quality: {data['fit_quality']}")
+    for iso_result in data.get("isotope_results", []):
+        print(f"  {iso_result['isotope']}: {iso_result['abundance']:.4f}")
+else:
+    print(f"Analysis error: {analysis['error']}")
+```
+
+## Checking MCP Availability
+
+```python
+from pleiades.mcp import MCP_AVAILABLE, check_mcp_available
+
+if MCP_AVAILABLE:
+    from pleiades.mcp.server import get_server
+    server = get_server()
+else:
+    print("MCP not installed. Run: pip install pleiades-neutron[mcp]")
+
+# Or raise ImportError with instructions
+check_mcp_available()  # Raises if not installed
+```
+
+## Security Notes
+
+> **WARNING**: MCP tools have file system access to any path the server process can read.
+
+- Path traversal (`../`) is **explicitly permitted** by design
+- An AI client can read any file accessible to the MCP server process user
+- **Never** run the MCP server as root or with elevated privileges
+- Consider OS-level sandboxing (Docker, chroot) in production environments
+- Use filesystem ACLs to restrict access to sensitive data directories
+
+## Troubleshooting
+
+### "No SAMMY backend available"
+
+No backend could be found. Solutions:
+1. **Docker**: Ensure Docker is running (`docker info`)
+2. **Local**: Install SAMMY and ensure it's in your PATH
+
+### "ENDF parameter file not found for isotope: X"
+
+The specified isotope doesn't have ENDF data available. Solutions:
+1. Check isotope format (e.g., `"Hf-177"` not `"177Hf"`)
+2. Verify the isotope exists in the ENDF library
+3. Use a different isotope that has available data
+
+### "Docker not running" or connection errors
+
+```bash
+# Check Docker status
+docker info
+
+# Start Docker if needed (Linux)
+sudo systemctl start docker
+
+# On macOS/Windows, start Docker Desktop
+```
+
+### MCP server not connecting
+
+1. Verify `.mcp.json` is in your project root
+2. Check the command path is correct
+3. Restart Claude Code after editing `.mcp.json`
+
+## Related Documentation
+
+- [Manifest Format Specification](manifest-format.md)
+- [Integration Pattern Guide](integration-pattern.md) - How to add MCP to other scientific packages
+- [MCP Protocol Specification](https://modelcontextprotocol.io/)

--- a/docs/mcp/integration-pattern.md
+++ b/docs/mcp/integration-pattern.md
@@ -391,7 +391,7 @@ Use `parameter_descriptions` to provide AI-friendly documentation:
     description="Analyze neutron resonance data using SAMMY fitting",
     parameter_descriptions={
         "dataset_path": "Path to directory containing resonance data files",
-        "backend": "Execution backend: 'auto', 'local', 'docker', or 'nova'",
+        "backend": "Execution backend: 'auto', 'local', or 'docker'",
         "isotopes": "List of isotopes to analyze (e.g., ['Hf-177', 'Hf-178'])",
     },
 )

--- a/docs/mcp/integration-pattern.md
+++ b/docs/mcp/integration-pattern.md
@@ -128,7 +128,7 @@ from copy import deepcopy
 
 F = TypeVar("F", bound=Callable[..., Any])
 
-_tool_registry: dict[str, dict[str, Any]] = {}
+_mcp_registry: dict[str, dict[str, Any]] = {}
 
 def mcp_tool(
     func: F | None = None,
@@ -143,10 +143,10 @@ def mcp_tool(
         tool_name = name or f.__name__
         tool_desc = description or (f.__doc__ or "").split("\n")[0]
 
-        if tool_name in _tool_registry:
+        if tool_name in _mcp_registry:
             raise ValueError(f"Tool '{tool_name}' already registered")
 
-        _tool_registry[tool_name] = {
+        _mcp_registry[tool_name] = {
             "name": tool_name,
             "description": tool_desc,
             "func": f,
@@ -160,16 +160,16 @@ def mcp_tool(
 
 def get_registered_tools() -> dict[str, dict[str, Any]]:
     """Return deep copy of tool registry."""
-    return deepcopy(_tool_registry)
+    return deepcopy(_mcp_registry)
 
 def clear_registry() -> None:
     """Clear all registered tools (for testing)."""
-    _tool_registry.clear()
+    _mcp_registry.clear()
 ```
 
 **Registry Scope Notes:**
 - The registry is **global** within your package. All modules importing from `yourpackage.mcp.decorators` share the same registry.
-- If multiple packages copy this pattern, each has its **own isolated registry** (different `_tool_registry` variables).
+- If multiple packages copy this pattern, each has its **own isolated registry** (different `_mcp_registry` variables).
 - `clear_registry()` removes ALL tools from your package's registry - use it in tests to ensure clean state between test cases.
 - Tools are registered at **import time** when Python executes the `@mcp_tool` decorator.
 
@@ -282,6 +282,8 @@ if MCP_AVAILABLE:
 
 ```python
 # src/yourpackage/mcp/__main__.py
+import sys
+
 def run() -> None:
     """Entry point for python -m yourpackage.mcp"""
     try:
@@ -289,10 +291,10 @@ def run() -> None:
         main()
     except ImportError as e:
         print(f"Error: {e}")
-        exit(1)
+        sys.exit(1)
     except KeyboardInterrupt:
         print("\nServer stopped.")
-        exit(0)
+        sys.exit(0)
 
 if __name__ == "__main__":
     run()
@@ -497,4 +499,4 @@ The minimal estimates above are for a basic implementation. Production code (lik
 
 - [MCP Protocol Specification](https://modelcontextprotocol.io/)
 - [FastMCP Documentation](https://gofastmcp.com/)
-- [PLEIADES MCP Implementation](https://github.com/lanl/PLEIADES/tree/feature/163-mcp-integration/src/pleiades/mcp)
+- [PLEIADES MCP Implementation](https://github.com/lanl/PLEIADES/tree/next/src/pleiades/mcp)

--- a/docs/mcp/integration-pattern.md
+++ b/docs/mcp/integration-pattern.md
@@ -1,0 +1,500 @@
+# MCP Integration Pattern for Scientific Software
+
+This guide documents the pattern used to add MCP capabilities to PLEIADES, designed for reuse in other scientific packages (iBeatles, etc.).
+
+> **Note**: This pattern was developed and tested with FastMCP 2.12.0+ and Pydantic 2.x.
+
+## Architecture Overview
+
+The MCP integration uses a layered architecture that keeps MCP concerns separate from core functionality:
+
+```mermaid
+flowchart TD
+    subgraph AI["AI Application (Claude Code, Claude Desktop)"]
+    end
+
+    subgraph MCP["MCP Server Layer"]
+        S["server.py (FastMCP)"]
+        D["decorators.py (@mcp_tool)"]
+        T["tools.py (JSON wrappers)"]
+    end
+
+    subgraph WF["Workflows Layer"]
+        W["High-level functions with Pydantic models"]
+    end
+
+    subgraph Core["Core Library"]
+        C["Domain-specific implementation"]
+    end
+
+    AI -->|MCP Protocol| MCP
+    MCP -->|Python calls| WF
+    WF --> Core
+```
+
+**Key principle**: The MCP layer is a thin wrapper. All logic lives in the workflows and core layers, which work without MCP.
+
+## Decorator Approaches
+
+There are two ways to expose functions as MCP tools:
+
+### Option A: FastMCP's Built-in Decorator (Simpler)
+
+FastMCP 2.x provides a built-in `@server.tool()` decorator:
+
+```python
+from fastmcp import FastMCP
+
+server = FastMCP("my-server")
+
+@server.tool()
+def my_function(path: str) -> dict:
+    """This function is automatically exposed as an MCP tool."""
+    return {"result": "success"}
+```
+
+**Use this when**: You're building a simple MCP server and don't need to switch backends.
+
+### Option B: Custom Registry Decorator (PLEIADES Pattern)
+
+PLEIADES uses a custom `@mcp_tool` decorator with a registry abstraction:
+
+```python
+from pleiades.mcp.decorators import mcp_tool
+
+@mcp_tool(description="Analyze data")
+def analyze(path: str) -> dict:
+    return {"result": "success"}
+```
+
+**Use this when**:
+- You want to decouple from specific MCP implementations
+- You may switch backends in the future (FastMCP → another library)
+- You need custom parameter descriptions or validation
+- You want tools to be testable without MCP server running
+
+**This guide documents Option B** (the custom decorator pattern) because it provides more flexibility for scientific software that may need to support multiple deployment scenarios.
+
+## Implementation Steps
+
+### Step 1: Create Workflows Module
+
+Create high-level functions that orchestrate your domain logic. These should:
+- Accept simple types (Path, str, basic types)
+- Return Pydantic models for structured output
+- Handle errors gracefully
+- Be usable without MCP
+
+```python
+# src/yourpackage/workflows/analysis.py
+from pathlib import Path
+from pydantic import BaseModel
+
+class AnalysisResult(BaseModel):
+    success: bool
+    metric: float | None
+    error_message: str | None
+
+def run_analysis(data_path: Path, method: str = "default") -> AnalysisResult:
+    """High-level analysis function.
+
+    This function is independent of MCP and can be used directly.
+    """
+    try:
+        # Call your core library functions
+        result = core_library.analyze(data_path, method)
+        return AnalysisResult(
+            success=True,
+            metric=result.metric,
+            error_message=None
+        )
+    except Exception as e:
+        return AnalysisResult(
+            success=False,
+            metric=None,
+            error_message=str(e)
+        )
+```
+
+### Step 2: Create Decorator Module
+
+Implement a registry-based decorator for tool registration:
+
+```python
+# src/yourpackage/mcp/decorators.py
+from __future__ import annotations
+from typing import Any, Callable, TypeVar
+from copy import deepcopy
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_tool_registry: dict[str, dict[str, Any]] = {}
+
+def mcp_tool(
+    func: F | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    parameter_descriptions: dict[str, str] | None = None,
+) -> F | Callable[[F], F]:
+    """Register a function as an MCP tool."""
+
+    def decorator(f: F) -> F:
+        tool_name = name or f.__name__
+        tool_desc = description or (f.__doc__ or "").split("\n")[0]
+
+        if tool_name in _tool_registry:
+            raise ValueError(f"Tool '{tool_name}' already registered")
+
+        _tool_registry[tool_name] = {
+            "name": tool_name,
+            "description": tool_desc,
+            "func": f,
+            "parameter_descriptions": parameter_descriptions,
+        }
+        return f
+
+    if func is not None:
+        return decorator(func)
+    return decorator
+
+def get_registered_tools() -> dict[str, dict[str, Any]]:
+    """Return deep copy of tool registry."""
+    return deepcopy(_tool_registry)
+
+def clear_registry() -> None:
+    """Clear all registered tools (for testing)."""
+    _tool_registry.clear()
+```
+
+**Registry Scope Notes:**
+- The registry is **global** within your package. All modules importing from `yourpackage.mcp.decorators` share the same registry.
+- If multiple packages copy this pattern, each has its **own isolated registry** (different `_tool_registry` variables).
+- `clear_registry()` removes ALL tools from your package's registry - use it in tests to ensure clean state between test cases.
+- Tools are registered at **import time** when Python executes the `@mcp_tool` decorator.
+
+### Step 3: Create Tools Module
+
+Wrap workflow functions with JSON serialization:
+
+```python
+# src/yourpackage/mcp/tools.py
+from pathlib import Path
+from typing import Any
+
+from yourpackage.mcp.decorators import mcp_tool
+from yourpackage.workflows import analysis
+
+def _to_json(obj: Any) -> Any:
+    """Convert objects to JSON-serializable format."""
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+    if isinstance(obj, Path):
+        return str(obj)
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump(mode="json")
+    if isinstance(obj, dict):
+        return {k: _to_json(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_to_json(item) for item in obj]
+    return str(obj)
+
+# Note: Use domain-specific parameter names for your package
+# PLEIADES uses: dataset_path, backend, isotopes
+# Your package might use: data_path, method, options, etc.
+@mcp_tool(
+    description="Run analysis on a dataset",
+    parameter_descriptions={
+        "data_path": "Path to the dataset directory",
+        "method": "Analysis method to use",
+    },
+)
+def run_analysis(data_path: str, method: str = "default") -> dict:
+    """MCP wrapper for analysis workflow."""
+    try:
+        result = analysis.run_analysis(Path(data_path), method)
+        return {"status": "success", "data": _to_json(result)}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+```
+
+### Step 4: Create Server Module
+
+Set up FastMCP with auto-discovery:
+
+```python
+# src/yourpackage/mcp/server.py
+from typing import Any
+
+def discover_tools() -> dict[str, dict[str, Any]]:
+    """Discover all registered MCP tools."""
+    from yourpackage.mcp.decorators import get_registered_tools
+    return get_registered_tools()
+
+def register_tools(server: Any) -> None:
+    """Register discovered tools with FastMCP server."""
+    tools = discover_tools()
+    for name, info in tools.items():
+        server.tool(name=name, description=info["description"])(info["func"])
+
+def get_server() -> Any:
+    """Get FastMCP server instance."""
+    from fastmcp import FastMCP
+    return FastMCP("yourpackage-mcp")
+
+def main() -> None:
+    """Start the MCP server."""
+    # Import tools module to trigger registration
+    import yourpackage.mcp.tools  # noqa: F401
+
+    server = get_server()
+    register_tools(server)
+    server.run()
+```
+
+### Step 5: Create Package Init
+
+Handle optional dependency gracefully:
+
+```python
+# src/yourpackage/mcp/__init__.py
+try:
+    from fastmcp import FastMCP
+    MCP_AVAILABLE = True
+except ImportError:
+    MCP_AVAILABLE = False
+    FastMCP = None
+
+def check_mcp_available() -> None:
+    """Raise ImportError if MCP dependencies not installed."""
+    if not MCP_AVAILABLE:
+        raise ImportError(
+            "MCP dependencies not installed.\n"
+            "Install with: pip install yourpackage[mcp]"
+        )
+
+__all__ = ["MCP_AVAILABLE", "check_mcp_available"]
+if MCP_AVAILABLE:
+    __all__.append("FastMCP")
+```
+
+### Step 6: Create Module Entry Point
+
+```python
+# src/yourpackage/mcp/__main__.py
+def run() -> None:
+    """Entry point for python -m yourpackage.mcp"""
+    try:
+        from yourpackage.mcp.server import main
+        main()
+    except ImportError as e:
+        print(f"Error: {e}")
+        exit(1)
+    except KeyboardInterrupt:
+        print("\nServer stopped.")
+        exit(0)
+
+if __name__ == "__main__":
+    run()
+```
+
+### Step 7: Configure pyproject.toml
+
+```toml
+[project.optional-dependencies]
+# Pin to FastMCP 2.x - version 3.x may have breaking API changes
+# The >=2.12.0 minimum ensures Pydantic 2.x compatibility
+mcp = ["fastmcp>=2.12.0,<3"]
+
+[project.scripts]
+yourpackage-mcp = "yourpackage.mcp.server:main"
+```
+
+## Directory Structure
+
+```
+src/yourpackage/
+├── mcp/
+│   ├── __init__.py      # MCP_AVAILABLE check
+│   ├── __main__.py      # Module entry point
+│   ├── decorators.py    # @mcp_tool registry
+│   ├── server.py        # FastMCP server setup
+│   └── tools.py         # MCP tool wrappers
+├── workflows/
+│   ├── __init__.py
+│   ├── models.py        # Pydantic models
+│   └── analysis.py      # High-level functions
+└── core/
+    └── ...              # Domain-specific code
+```
+
+## Design Principles
+
+### 1. Optional Dependency
+
+MCP should never be required for core functionality:
+
+```python
+# Good: Graceful degradation
+if MCP_AVAILABLE:
+    from yourpackage.mcp import server
+
+# Bad: Hard dependency
+from yourpackage.mcp import server  # Crashes if fastmcp not installed
+```
+
+### 2. Thin Wrapper Layer
+
+MCP tools should only:
+- Convert types (str → Path)
+- Call workflow functions
+- Serialize results to JSON
+- Handle errors
+
+They should NOT contain business logic.
+
+### 3. Consistent Output Format
+
+All tools return the same structure:
+
+```python
+# Success
+{"status": "success", "data": {...}}
+
+# Error
+{"status": "error", "error": "message"}
+```
+
+### 4. Type Safety
+
+Use type hints everywhere:
+
+```python
+@mcp_tool(
+    parameter_descriptions={
+        "path": "Dataset path",
+        "method": "Analysis method",
+    },
+)
+def analyze(path: str, method: str = "default") -> dict:
+    ...
+```
+
+### 5. Documentation via Decorators
+
+Use `parameter_descriptions` to provide AI-friendly documentation:
+
+```python
+@mcp_tool(
+    description="Analyze neutron resonance data using SAMMY fitting",
+    parameter_descriptions={
+        "dataset_path": "Path to directory containing resonance data files",
+        "backend": "Execution backend: 'auto', 'local', 'docker', or 'nova'",
+        "isotopes": "List of isotopes to analyze (e.g., ['Hf-177', 'Hf-178'])",
+    },
+)
+def analyze_resonance(...):
+    ...
+```
+
+## Testing
+
+### Unit Tests for Decorators
+
+```python
+def test_mcp_tool_registration():
+    from yourpackage.mcp.decorators import mcp_tool, get_registered_tools, clear_registry
+
+    clear_registry()
+
+    @mcp_tool(description="Test tool")
+    def my_tool(x: int) -> int:
+        return x * 2
+
+    tools = get_registered_tools()
+    assert "my_tool" in tools
+    assert tools["my_tool"]["description"] == "Test tool"
+    assert my_tool(5) == 10  # Original function works
+```
+
+### Integration Tests
+
+```python
+def test_tool_execution():
+    from yourpackage.mcp.tools import run_analysis
+
+    result = run_analysis("/path/to/test/data")
+    assert result["status"] in ("success", "error")
+    if result["status"] == "success":
+        assert "data" in result
+```
+
+## Common Pitfalls
+
+### 1. Import Timing for Decorator Registration
+
+Import tools module inside `main()`, not at module level. This ensures decorators are executed at the right time:
+
+```python
+# Good: Import inside main() triggers registration before server starts
+def main():
+    import yourpackage.mcp.tools  # Triggers @mcp_tool decorator registration
+    ...
+
+# Bad: Module-level import may run before registry is ready
+import yourpackage.mcp.tools
+def main():
+    ...
+```
+
+### 2. Non-Serializable Returns
+
+Always convert complex types:
+
+```python
+# Bad: Returns Path object
+return {"path": Path("/some/path")}
+
+# Good: Convert to string
+return {"path": str(Path("/some/path"))}
+```
+
+### 3. Missing Error Handling
+
+Always wrap workflow calls:
+
+```python
+# Bad: Exception crashes MCP
+result = workflow.analyze(path)
+return {"data": result}
+
+# Good: Return error in standard format
+try:
+    result = workflow.analyze(path)
+    return {"status": "success", "data": result}
+except Exception as e:
+    return {"status": "error", "error": str(e)}
+```
+
+## Estimated Code Size
+
+For a minimal MCP integration (simplified version of what PLEIADES uses):
+
+| Component | Lines of Code (Minimal) | Lines of Code (Full-featured) |
+|-----------|------------------------|------------------------------|
+| decorators.py | ~50 | ~250 (with validation, docs) |
+| server.py | ~40 | ~300 (with schema generation) |
+| tools.py | ~30 per tool | ~80 per tool (with serialization) |
+| __init__.py | ~20 | ~30 |
+| __main__.py | ~15 | ~25 |
+| **Total** | ~150 + 30/tool | ~600 + 80/tool |
+
+The minimal estimates above are for a basic implementation. Production code (like PLEIADES) typically includes additional features: comprehensive type validation, detailed JSON schema generation, robust error handling, and extensive documentation.
+
+> **Note**: These estimates exclude test code. A thorough test suite (unit tests for decorators, server, and tools; integration tests for end-to-end workflows) typically adds 200-500 additional lines depending on coverage requirements.
+
+## References
+
+- [MCP Protocol Specification](https://modelcontextprotocol.io/)
+- [FastMCP Documentation](https://gofastmcp.com/)
+- [PLEIADES MCP Implementation](https://github.com/lanl/PLEIADES/tree/feature/163-mcp-integration/src/pleiades/mcp)

--- a/docs/mcp/manifest-format.md
+++ b/docs/mcp/manifest-format.md
@@ -40,7 +40,7 @@ These fields have defaults if not specified:
 | `name` | string | `"unknown"` | Unique dataset identifier |
 | `description` | string | `""` | Human-readable description |
 | `version` | string | `"1.0.0"` | Manifest version (semver) |
-| `created` | string | `""` | ISO-8601 timestamp (e.g., `2024-06-15T10:30:45`) |
+| `created` | string | `""` | ISO-8601 timestamp (e.g., `2024-06-15T10:30:45Z`) |
 
 ### Experiment Metadata (Optional)
 

--- a/docs/mcp/manifest-format.md
+++ b/docs/mcp/manifest-format.md
@@ -1,0 +1,247 @@
+# Manifest Format Specification
+
+PLEIADES uses manifest files to describe neutron resonance datasets. Manifests contain metadata about the sample, experiment conditions, and analysis parameters.
+
+## File Format
+
+Manifests use YAML frontmatter followed by an optional Markdown body:
+
+```markdown
+---
+name: sample-identifier
+description: Human-readable description
+version: "1.0.0"
+# ... other fields
+---
+
+# Optional Markdown Content
+
+Analysis notes, processing instructions, or other documentation.
+```
+
+## File Naming
+
+PLEIADES searches for manifest files in this order:
+
+1. `manifest_intermediate.md`
+2. `smcp_manifest.md`
+3. `manifest.md`
+
+Place the manifest file in your dataset root directory.
+
+## Field Reference
+
+### Required Fields
+
+These fields have defaults if not specified:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | `"unknown"` | Unique dataset identifier |
+| `description` | string | `""` | Human-readable description |
+| `version` | string | `"1.0.0"` | Manifest version (semver) |
+| `created` | string | `""` | ISO-8601 timestamp (e.g., `2024-06-15T10:30:45`) |
+
+### Experiment Metadata (Optional)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `facility` | string | Facility name (e.g., `"SNS"`, `"LANSCE"`) |
+| `beamline` | string | Beamline identifier (e.g., `"VENUS"`) |
+| `detector` | string | Detector type (e.g., `"MCP"`) |
+| `sample_id` | string | Sample reference number |
+
+### Primary Isotope
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `isotope` | string | Primary isotope for analysis |
+
+**Accepted formats:**
+- Full specification: `"Au-197"`, `"Hf-177"`, `"U-235"`
+- Element only: `"Hf"` (uses natural abundance)
+- Natural indicator: `"Hf-nat"` (equivalent to element only)
+
+### Material Properties (Optional)
+
+Nested object describing physical properties:
+
+```yaml
+material_properties:
+  density_g_cm3: 19.32      # Required if section present, must be > 0
+  atomic_mass_amu: 196.97   # Required if section present, must be > 0
+  temperature_k: 293.6      # Optional, must be > 0 if provided
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `density_g_cm3` | float | Yes* | Material density in g/cm³ |
+| `atomic_mass_amu` | float | Yes* | Atomic mass in amu |
+| `temperature_k` | float | No | Sample temperature in Kelvin |
+
+*Required if `material_properties` section is present.
+
+### Isotope Composition
+
+PLEIADES supports three ways to specify which isotopes to analyze:
+
+#### Option 1: Explicit Isotope List (Highest Priority)
+
+```yaml
+isotope: Hf-177
+isotopes:
+  - Hf-176
+  - Hf-177
+  - Hf-178
+```
+
+When `isotopes` is set, only these isotopes are included regardless of natural abundance. Each isotope receives equal weight in the analysis.
+
+**Validation rules:**
+- Each entry must match format: `Element-MassNumber` (e.g., `"Hf-177"`)
+- Element symbol: 1-2 characters, first uppercase
+- Mass number: numeric only (metastable states like `"U-235m"` are not supported)
+
+> **Important**: Each isotope you specify must have ENDF parameter data available. If an isotope lacks ENDF data, the analysis will fail with "ENDF parameter file not found for isotope: X".
+
+**Validation failure behavior**: If isotope format is invalid, a `ValueError` is raised during manifest parsing (e.g., "Invalid isotope format: '177Hf'. Expected format: 'Element-MassNumber' (e.g., 'Hf-177')").
+
+#### Option 2: Custom Enrichment
+
+```yaml
+isotope: U-235
+use_natural_abundance: false
+enrichment:
+  U-235: 0.90
+  U-238: 0.10
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `use_natural_abundance` | boolean | `true` | Whether to use natural abundances |
+| `enrichment` | dict | `null` | Custom isotope composition |
+
+**Enrichment validation rules:**
+- All values must be in range [0, 1]
+- Values must sum to ~1.0 (within 1% tolerance)
+- Keys must be explicit isotopes (e.g., `"U-235"`, not `"U"`)
+
+**Validation failure behavior**: If enrichment validation fails, a `ValueError` is raised during manifest parsing with a descriptive message (e.g., "Enrichment values must sum to approximately 1.0").
+
+#### Option 3: Natural Abundance (Default)
+
+```yaml
+isotope: Au-197
+use_natural_abundance: true  # This is the default
+```
+
+Uses isotope data from PLEIADES internal database to determine natural abundances.
+
+### Priority Order
+
+When determining isotope composition, PLEIADES uses this priority:
+
+1. **User-specified isotopes parameter** (in `analyze_resonance` call)
+2. **Manifest `isotopes` field** (explicit list)
+3. **Manifest `enrichment` field** (when `use_natural_abundance: false`)
+4. **Natural abundance lookup** (default behavior)
+
+## Complete Example
+
+```yaml
+---
+name: Hf_foil_sample_001
+description: >
+  Natural hafnium foil resonance measurement from VENUS beamline.
+  Sample thickness: 0.5mm, measured at room temperature.
+version: "2.0.0"
+created: "2024-11-15T14:30:00Z"
+
+# Experiment metadata
+facility: SNS
+beamline: VENUS
+detector: MCP
+sample_id: IPTS-35945-HF001
+
+# Analysis parameters
+isotope: Hf-177
+
+# Material properties
+material_properties:
+  density_g_cm3: 13.31
+  atomic_mass_amu: 178.49
+  temperature_k: 295.0
+
+# Isotope composition - analyze specific isotopes only
+isotopes:
+  - Hf-176
+  - Hf-177
+  - Hf-178
+  - Hf-179
+  - Hf-180
+---
+
+# Analysis Notes
+
+## Sample Preparation
+
+Foil was cleaned with ethanol and mounted in standard sample holder.
+
+## Expected Results
+
+Primary resonances expected at:
+- Hf-177: 1.1 eV, 2.4 eV, 5.9 eV
+- Hf-178: 7.8 eV
+
+## Post-Processing
+
+Results will be compared with ENDF/B-VIII.0 library values.
+```
+
+## Minimal Example
+
+For quick testing, a minimal manifest:
+
+```yaml
+---
+name: quick-test
+isotope: Au-197
+---
+```
+
+## Synthetic Data Example
+
+For documentation and testing without real experimental data:
+
+```yaml
+---
+name: synthetic-gold-sample
+description: Synthetic Au-197 data for testing and documentation
+version: "1.0.0"
+created: "2024-01-01T00:00:00Z"
+
+facility: Simulated
+beamline: Virtual
+isotope: Au-197
+
+material_properties:
+  density_g_cm3: 19.32
+  atomic_mass_amu: 196.97
+  temperature_k: 300.0
+
+use_natural_abundance: true
+---
+
+# Synthetic Dataset
+
+This manifest describes synthetic/simulated data for testing purposes.
+Not derived from actual experimental measurements.
+```
+
+## Parsing Notes
+
+- YAML datetime values are automatically converted to ISO format strings
+- Empty `material_properties` sections return `null`
+- Invalid material properties are logged but don't fail parsing
+- All raw YAML data is preserved in `raw_frontmatter` for extensibility
+- Markdown horizontal rules (`---`) in the body are handled correctly

--- a/src/pleiades/mcp/tools.py
+++ b/src/pleiades/mcp/tools.py
@@ -186,7 +186,7 @@ def extract_resonance_manifest(dataset_path: str) -> dict:
     description="Perform neutron resonance analysis on a dataset using SAMMY.",
     parameter_descriptions={
         "dataset_path": "Path to the dataset directory containing resonance data.",
-        "backend": "SAMMY execution backend: 'auto', 'local', 'docker', or 'nova'.",
+        "backend": "SAMMY execution backend: 'auto', 'local', or 'docker'.",
         "isotopes": "List of isotopes to analyze (e.g., ['Hf-177', 'Hf-178']). If not specified, all natural isotopes for the element are used.",
     },
 )


### PR DESCRIPTION
## Summary

- Add comprehensive MCP documentation to `docs/mcp/`
- README.md: Installation, quick start, tool reference, troubleshooting
- manifest-format.md: YAML frontmatter specification with validation rules
- integration-pattern.md: Reusable pattern for adding MCP to scientific packages

## Changes

### docs/mcp/README.md
- Installation instructions (PyPI, editable, Pixi)
- Quick start guide with `.mcp.json` configuration
- Complete tool reference with parameters and return values
- Mermaid workflow diagram
- Backend options and isotope selection priority
- Security notes and troubleshooting section

### docs/mcp/manifest-format.md
- YAML frontmatter specification
- Field reference (required, optional, material properties)
- Isotope composition options (explicit list, enrichment, natural abundance)
- Priority order documentation
- Complete and minimal examples

### docs/mcp/integration-pattern.md
- Architecture overview with Mermaid diagram
- Decorator approaches (FastMCP built-in vs custom registry)
- Step-by-step implementation guide
- Design principles and common pitfalls
- Realistic code size estimates

## Test plan

- [x] Verify Mermaid diagrams render correctly on GitHub
- [x] Check all internal links work
- [ ] Review for technical accuracy against implementation

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)