### PR TITLE
feat(imaging): add TempFileManager for batch temp file lifecycle

### DIFF
--- a/src/pleiades/imaging/orchestrator.py
+++ b/src/pleiades/imaging/orchestrator.py
@@ -20,7 +20,7 @@ from tqdm import tqdm
 
 from pleiades.imaging.config import ImagingConfig
 from pleiades.imaging.models import PixelFitResult, PixelSpectrum
-from pleiades.imaging.temp_manager import TempFileManager
+from pleiades.imaging.temp_manager import _BYTES_PER_GB, TempFileManager
 from pleiades.sammy.backends.local import LocalSammyRunner
 from pleiades.sammy.config import LocalSammyConfig
 from pleiades.sammy.interface import SammyFilesMultiMode
@@ -183,13 +183,16 @@ def _check_worker_disk_space(
 ) -> Optional[str]:
     """Check disk space in a worker subprocess, replicating TempFileManager logic.
 
+    Uses ``_BYTES_PER_GB`` from ``temp_manager`` to stay consistent with the
+    parent-process disk checks.
+
     Returns None if space is sufficient, or an error message string if not.
     """
     import shutil
 
     try:
         usage = shutil.disk_usage(base_dir)
-        free_gb = usage.free / (1024**3)
+        free_gb = usage.free / _BYTES_PER_GB
         if free_gb < required_gb:
             return f"{free_gb:.2f} GB free, need at least {required_gb} GB"
         if initial_free_gb is not None and max_disk_usage_gb is not None:
@@ -246,6 +249,8 @@ def _fit_pixel_worker(
         PixelFitResult with fitted abundances and chi-squared, or failure info
     """
     if temp_base_dir is not None:
+        # Ensure base dir exists so shutil.disk_usage doesn't fail with FileNotFoundError
+        temp_base_dir.mkdir(parents=True, exist_ok=True)
         # Check disk space before creating workspace (replicates TempFileManager.check_disk_space)
         disk_err = _check_worker_disk_space(temp_base_dir, max_disk_usage_gb, initial_free_gb)
         if disk_err is not None:
@@ -260,6 +265,11 @@ def _fit_pixel_worker(
         # Include attempt_id in dir name so retries don't collide with timed-out zombie workers
         dir_name = f"pixel_{pixel.row}_{pixel.col}_a{attempt_id}"
         temp_path = temp_base_dir / dir_name
+        # Remove any stale workspace from a previous crashed run to avoid contamination
+        if temp_path.exists():
+            import shutil
+
+            shutil.rmtree(temp_path, ignore_errors=True)
         temp_path.mkdir(parents=True, exist_ok=True)
     else:
         temp_path = None  # Sentinel; set below in context manager
@@ -750,7 +760,7 @@ class BatchFittingOrchestrator:
         temp_base_dir = self.temp_manager.base_dir if self.temp_manager is not None else None
         cleanup_policy = self.temp_manager.cleanup_policy if self.temp_manager is not None else "immediate"
         max_disk_usage_gb = self.temp_manager.max_disk_usage_gb if self.temp_manager is not None else None
-        initial_free_gb = self.temp_manager._initial_free_gb if self.temp_manager is not None else None
+        initial_free_gb = self.temp_manager.initial_free_gb if self.temp_manager is not None else None
 
         return {
             executor.submit(

--- a/src/pleiades/imaging/orchestrator.py
+++ b/src/pleiades/imaging/orchestrator.py
@@ -174,6 +174,32 @@ class GracefulShutdownHandler:
         self.uninstall()
 
 
+def _check_worker_disk_space(
+    base_dir: Path,
+    max_disk_usage_gb: Optional[float],
+    initial_free_gb: Optional[float],
+    required_gb: float = 0.1,
+) -> Optional[str]:
+    """Check disk space in a worker subprocess, replicating TempFileManager logic.
+
+    Returns None if space is sufficient, or an error message string if not.
+    """
+    import shutil
+
+    try:
+        usage = shutil.disk_usage(base_dir)
+        free_gb = usage.free / (1024**3)
+        if free_gb < required_gb:
+            return f"{free_gb:.2f} GB free, need at least {required_gb} GB"
+        if initial_free_gb is not None and max_disk_usage_gb is not None:
+            consumed_gb = initial_free_gb - free_gb
+            if consumed_gb > max_disk_usage_gb:
+                return f"{consumed_gb:.2f} GB consumed, limit is {max_disk_usage_gb} GB"
+    except Exception as e:
+        return f"disk check failed: {e}"
+    return None
+
+
 def _fit_pixel_worker(
     pixel: PixelSpectrum,
     imaging_config: ImagingConfig,
@@ -183,6 +209,9 @@ def _fit_pixel_worker(
     shared_endf_directory: Optional[Path] = None,
     temp_base_dir: Optional[Path] = None,
     cleanup_policy: str = "immediate",
+    attempt_id: int = 0,
+    max_disk_usage_gb: Optional[float] = None,
+    initial_free_gb: Optional[float] = None,
 ) -> PixelFitResult:
     """Worker function to fit a single pixel using SAMMY.
 
@@ -204,12 +233,32 @@ def _fit_pixel_worker(
         temp_base_dir: Optional base directory for managed temp files. When provided,
             creates per-pixel workspaces under this directory instead of the system temp.
         cleanup_policy: Cleanup policy when using temp_base_dir ("immediate", "batch", "manual").
+        attempt_id: Attempt number for this pixel (0 = first attempt, 1+ = retries).
+            Used to create unique workspace directories so that timed-out zombie workers
+            from a previous attempt do not collide with retries.
+        max_disk_usage_gb: Maximum disk usage limit from TempFileManager. When set,
+            the worker checks disk space before creating the workspace.
+        initial_free_gb: Free space recorded at batch start, used with max_disk_usage_gb
+            to enforce the consumed-space limit.
 
     Returns:
         PixelFitResult with fitted abundances and chi-squared, or failure info
     """
     if temp_base_dir is not None:
-        temp_path = temp_base_dir / f"pixel_{pixel.row}_{pixel.col}"
+        # Check disk space before creating workspace (replicates TempFileManager.check_disk_space)
+        disk_err = _check_worker_disk_space(temp_base_dir, max_disk_usage_gb, initial_free_gb)
+        if disk_err is not None:
+            return PixelFitResult(
+                row=pixel.row,
+                col=pixel.col,
+                fit_results=None,
+                success=False,
+                error_message=f"Disk space check failed: {disk_err}",
+                chi_squared=None,
+            )
+        # Include attempt_id in dir name so retries don't collide with timed-out zombie workers
+        dir_name = f"pixel_{pixel.row}_{pixel.col}_a{attempt_id}"
+        temp_path = temp_base_dir / dir_name
         temp_path.mkdir(parents=True, exist_ok=True)
     else:
         temp_path = None  # Sentinel; set below in context manager
@@ -586,7 +635,11 @@ class BatchFittingOrchestrator:
                             )
                             try:
                                 retry_futures = self._submit_pixels(
-                                    retry_executor, failed_pixels, shared_json_path, shared_endf_dir
+                                    retry_executor,
+                                    failed_pixels,
+                                    shared_json_path,
+                                    shared_endf_dir,
+                                    attempt_round=retry_round + 1,
                                 )
                                 all_future_maps.append(retry_futures)
                                 for p in failed_pixels:
@@ -678,10 +731,22 @@ class BatchFittingOrchestrator:
         pixels: List[PixelSpectrum],
         shared_json_path: Path,
         shared_endf_dir: Path,
+        attempt_round: int = 0,
     ) -> Dict[Future, PixelSpectrum]:
-        """Submit pixel fitting jobs to the executor."""
+        """Submit pixel fitting jobs to the executor.
+
+        Args:
+            executor: ProcessPoolExecutor to submit jobs to.
+            pixels: List of PixelSpectrum to fit.
+            shared_json_path: Path to pre-staged JSON config.
+            shared_endf_dir: Path to pre-staged ENDF directory.
+            attempt_round: Attempt number (0 = first, 1+ = retries). Included in
+                workspace directory names to prevent collisions with timed-out workers.
+        """
         temp_base_dir = self.temp_manager.base_dir if self.temp_manager is not None else None
         cleanup_policy = self.temp_manager.cleanup_policy if self.temp_manager is not None else "immediate"
+        max_disk_usage_gb = self.temp_manager.max_disk_usage_gb if self.temp_manager is not None else None
+        initial_free_gb = self.temp_manager._initial_free_gb if self.temp_manager is not None else None
 
         return {
             executor.submit(
@@ -694,6 +759,9 @@ class BatchFittingOrchestrator:
                 shared_endf_dir,
                 temp_base_dir,
                 cleanup_policy,
+                attempt_round,
+                max_disk_usage_gb,
+                initial_free_gb,
             ): pixel
             for pixel in pixels
         }

--- a/src/pleiades/imaging/orchestrator.py
+++ b/src/pleiades/imaging/orchestrator.py
@@ -5,6 +5,7 @@ This module provides tools for managing large-scale SAMMY resonance fitting jobs
 (262,144+ pixels for 512×512 images) with parallelism, checkpointing, and progress tracking.
 """
 
+import contextlib
 import pickle
 import signal
 import tempfile
@@ -571,13 +572,16 @@ class BatchFittingOrchestrator:
 
         # Execute remaining pixels in parallel
         if remaining_pixels:
-            # Use TempFileManager for shared workspace if provided, otherwise fall back
-            shared_ctx = (
-                self.temp_manager.shared_workspace("batch_shared")
-                if self.temp_manager is not None
-                else tempfile.TemporaryDirectory(prefix="batch_shared_")
-            )
-            with shared_ctx as shared_workspace_dir:
+            with contextlib.ExitStack() as exit_stack:
+                # Enter TempFileManager context first so _initial_free_gb is recorded
+                # (enables disk-cap enforcement in workers) and __exit__ runs cleanup
+                # for non-manual policies when the batch completes.
+                if self.temp_manager is not None:
+                    exit_stack.enter_context(self.temp_manager)
+                    shared_workspace_dir = exit_stack.enter_context(self.temp_manager.shared_workspace("batch_shared"))
+                else:
+                    shared_workspace_dir = exit_stack.enter_context(tempfile.TemporaryDirectory(prefix="batch_shared_"))
+
                 shared_json_path, shared_endf_dir = self._prepare_shared_sammy_inputs(Path(shared_workspace_dir))
 
                 with GracefulShutdownHandler() as shutdown_handler:

--- a/src/pleiades/imaging/orchestrator.py
+++ b/src/pleiades/imaging/orchestrator.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 
 from pleiades.imaging.config import ImagingConfig
 from pleiades.imaging.models import PixelFitResult, PixelSpectrum
+from pleiades.imaging.temp_manager import TempFileManager
 from pleiades.sammy.backends.local import LocalSammyRunner
 from pleiades.sammy.config import LocalSammyConfig
 from pleiades.sammy.interface import SammyFilesMultiMode
@@ -180,6 +181,8 @@ def _fit_pixel_worker(
     resolution_file: Optional[Path] = None,
     shared_json_config: Optional[Path] = None,
     shared_endf_directory: Optional[Path] = None,
+    temp_base_dir: Optional[Path] = None,
+    cleanup_policy: str = "immediate",
 ) -> PixelFitResult:
     """Worker function to fit a single pixel using SAMMY.
 
@@ -198,124 +201,171 @@ def _fit_pixel_worker(
         resolution_file: Optional path to resolution function file
         shared_json_config: Optional pre-staged JSON config path (shared across workers)
         shared_endf_directory: Optional pre-staged ENDF directory (shared across workers)
+        temp_base_dir: Optional base directory for managed temp files. When provided,
+            creates per-pixel workspaces under this directory instead of the system temp.
+        cleanup_policy: Cleanup policy when using temp_base_dir ("immediate", "batch", "manual").
 
     Returns:
         PixelFitResult with fitted abundances and chi-squared, or failure info
     """
-    with tempfile.TemporaryDirectory(prefix=f"pixel_{pixel.row}_{pixel.col}_") as temp_dir:
-        temp_path = Path(temp_dir)
+    if temp_base_dir is not None:
+        temp_path = temp_base_dir / f"pixel_{pixel.row}_{pixel.col}"
+        temp_path.mkdir(parents=True, exist_ok=True)
+    else:
+        temp_path = None  # Sentinel; set below in context manager
 
-        try:
-            # Step 1: Export pixel to CSV
-            csv_file = temp_path / "pixel.txt"
-            pixel.to_csv(csv_file)
+    return _fit_pixel_worker_impl(
+        pixel,
+        imaging_config,
+        sammy_executable,
+        resolution_file,
+        shared_json_config,
+        shared_endf_directory,
+        temp_path,
+        cleanup_policy,
+    )
 
-            # Step 2: Convert to .twenty format
-            twenty_file = temp_path / "pixel.twenty"
-            convert_csv_to_sammy_twenty(csv_file, twenty_file)
 
-            # Step 3: Resolve JSON config + ENDF staging
-            if shared_json_config is not None or shared_endf_directory is not None:
-                if shared_json_config is None or shared_endf_directory is None:
-                    raise ValueError("Both shared_json_config and shared_endf_directory must be provided together.")
-                if not shared_json_config.exists():
-                    raise FileNotFoundError(f"Shared JSON config not found: {shared_json_config}")
-                if not shared_endf_directory.exists():
-                    raise FileNotFoundError(f"Shared ENDF directory not found: {shared_endf_directory}")
-                json_path = shared_json_config
-                endf_directory = shared_endf_directory
-            else:
-                # Fallback mode for direct worker usage (tests/debug) without orchestrator pre-staging.
-                json_manager = JsonManager()
-                abundances = imaging_config.get_abundances()
-                json_path = json_manager.create_json_config(
-                    isotopes=imaging_config.isotopes, abundances=abundances, working_dir=temp_path
-                )
-                endf_directory = temp_path
+def _fit_pixel_worker_impl(
+    pixel: PixelSpectrum,
+    imaging_config: ImagingConfig,
+    sammy_executable: Path,
+    resolution_file: Optional[Path],
+    shared_json_config: Optional[Path],
+    shared_endf_directory: Optional[Path],
+    temp_path: Optional[Path],
+    cleanup_policy: str,
+) -> PixelFitResult:
+    """Inner implementation for _fit_pixel_worker.
 
-            # Step 4: Create .inp file
-            inp_file = temp_path / "sammy.inp"
-            material_props = imaging_config.get_material_properties()
-            InpManager.create_multi_isotope_inp(
-                inp_file,
-                title=f"Pixel ({pixel.row}, {pixel.col}) resonance fitting",
-                material_properties=material_props,
-                resolution_file_path=resolution_file,
+    Separated so that the managed-dir path and the tempfile.TemporaryDirectory fallback
+    share the same SAMMY workflow code without duplicating the try/except block.
+    """
+    import shutil
+
+    # If no managed temp_path was provided, fall back to a system temp directory
+    ctx = None
+    if temp_path is None:
+        ctx = tempfile.TemporaryDirectory(prefix=f"pixel_{pixel.row}_{pixel.col}_")
+        temp_path = Path(ctx.__enter__())
+
+    try:
+        # Step 1: Export pixel to CSV
+        csv_file = temp_path / "pixel.txt"
+        pixel.to_csv(csv_file)
+
+        # Step 2: Convert to .twenty format
+        twenty_file = temp_path / "pixel.twenty"
+        convert_csv_to_sammy_twenty(csv_file, twenty_file)
+
+        # Step 3: Resolve JSON config + ENDF staging
+        if shared_json_config is not None or shared_endf_directory is not None:
+            if shared_json_config is None or shared_endf_directory is None:
+                raise ValueError("Both shared_json_config and shared_endf_directory must be provided together.")
+            if not shared_json_config.exists():
+                raise FileNotFoundError(f"Shared JSON config not found: {shared_json_config}")
+            if not shared_endf_directory.exists():
+                raise FileNotFoundError(f"Shared ENDF directory not found: {shared_endf_directory}")
+            json_path = shared_json_config
+            endf_directory = shared_endf_directory
+        else:
+            # Fallback mode for direct worker usage (tests/debug) without orchestrator pre-staging.
+            json_manager = JsonManager()
+            abundances = imaging_config.get_abundances()
+            json_path = json_manager.create_json_config(
+                isotopes=imaging_config.isotopes, abundances=abundances, working_dir=temp_path
             )
+            endf_directory = temp_path
 
-            # Step 5: Execute SAMMY
-            files = SammyFilesMultiMode(
-                input_file=inp_file,
-                json_config_file=json_path,
-                data_file=twenty_file,
-                endf_directory=endf_directory,
-            )
+        # Step 4: Create .inp file
+        inp_file = temp_path / "sammy.inp"
+        material_props = imaging_config.get_material_properties()
+        InpManager.create_multi_isotope_inp(
+            inp_file,
+            title=f"Pixel ({pixel.row}, {pixel.col}) resonance fitting",
+            material_properties=material_props,
+            resolution_file_path=resolution_file,
+        )
 
-            config = LocalSammyConfig(
-                sammy_executable=sammy_executable,
-                working_dir=temp_path / "sammy_working",
-                output_dir=temp_path / "sammy_output",
-            )
-            runner = LocalSammyRunner(config)
-            runner.validate_config()
-            runner.prepare_environment(files)
-            result = runner.execute_sammy(files)
+        # Step 5: Execute SAMMY
+        files = SammyFilesMultiMode(
+            input_file=inp_file,
+            json_config_file=json_path,
+            data_file=twenty_file,
+            endf_directory=endf_directory,
+        )
 
-            if not result.success:
-                return PixelFitResult(
-                    row=pixel.row,
-                    col=pixel.col,
-                    fit_results=None,
-                    success=False,
-                    error_message=f"SAMMY execution failed: {result.error_message}",
-                    chi_squared=None,
-                )
+        config = LocalSammyConfig(
+            sammy_executable=sammy_executable,
+            working_dir=temp_path / "sammy_working",
+            output_dir=temp_path / "sammy_output",
+        )
+        runner = LocalSammyRunner(config)
+        runner.validate_config()
+        runner.prepare_environment(files)
+        result = runner.execute_sammy(files)
 
-            runner.collect_outputs(result)
-            runner.cleanup()
-
-            # Step 6: Parse results
-            lpt_file = temp_path / "sammy_output" / "SAMMY.LPT"
-            lst_file = temp_path / "sammy_output" / "SAMMY.LST"
-
-            results_manager = ResultsManager(lpt_file_path=lpt_file, lst_file_path=lst_file)
-
-            if not results_manager.run_results.fit_results:
-                return PixelFitResult(
-                    row=pixel.row,
-                    col=pixel.col,
-                    fit_results=None,
-                    success=False,
-                    error_message="No fit results found in SAMMY.LPT",
-                    chi_squared=None,
-                )
-
-            # Extract final fit results
-            final_fit = results_manager.run_results.fit_results[-1]
-            chi_sq = final_fit.get_chi_squared_results()
-
-            # Extract chi-squared value (can be None if fit failed to converge)
-            chi_squared_value = chi_sq.chi_squared if chi_sq is not None else None
-
-            return PixelFitResult(
-                row=pixel.row,
-                col=pixel.col,
-                fit_results=final_fit,
-                success=True,
-                error_message=None,
-                chi_squared=chi_squared_value,
-            )
-
-        except Exception as e:
-            logger.exception(f"Exception during pixel fitting at ({pixel.row}, {pixel.col})")
+        if not result.success:
             return PixelFitResult(
                 row=pixel.row,
                 col=pixel.col,
                 fit_results=None,
                 success=False,
-                error_message=f"Exception: {str(e)}",
+                error_message=f"SAMMY execution failed: {result.error_message}",
                 chi_squared=None,
             )
+
+        runner.collect_outputs(result)
+        runner.cleanup()
+
+        # Step 6: Parse results
+        lpt_file = temp_path / "sammy_output" / "SAMMY.LPT"
+        lst_file = temp_path / "sammy_output" / "SAMMY.LST"
+
+        results_manager = ResultsManager(lpt_file_path=lpt_file, lst_file_path=lst_file)
+
+        if not results_manager.run_results.fit_results:
+            return PixelFitResult(
+                row=pixel.row,
+                col=pixel.col,
+                fit_results=None,
+                success=False,
+                error_message="No fit results found in SAMMY.LPT",
+                chi_squared=None,
+            )
+
+        # Extract final fit results
+        final_fit = results_manager.run_results.fit_results[-1]
+        chi_sq = final_fit.get_chi_squared_results()
+
+        # Extract chi-squared value (can be None if fit failed to converge)
+        chi_squared_value = chi_sq.chi_squared if chi_sq is not None else None
+
+        return PixelFitResult(
+            row=pixel.row,
+            col=pixel.col,
+            fit_results=final_fit,
+            success=True,
+            error_message=None,
+            chi_squared=chi_squared_value,
+        )
+
+    except Exception as e:
+        logger.exception(f"Exception during pixel fitting at ({pixel.row}, {pixel.col})")
+        return PixelFitResult(
+            row=pixel.row,
+            col=pixel.col,
+            fit_results=None,
+            success=False,
+            error_message=f"Exception: {str(e)}",
+            chi_squared=None,
+        )
+    finally:
+        # Clean up temp directory
+        if ctx is not None:
+            ctx.__exit__(None, None, None)
+        elif cleanup_policy == "immediate":
+            shutil.rmtree(temp_path, ignore_errors=True)
 
 
 class BatchFittingOrchestrator:
@@ -344,6 +394,7 @@ class BatchFittingOrchestrator:
         sammy_executable: Path,
         n_workers: int = 4,
         resolution_file: Optional[Path] = None,
+        temp_manager: Optional[TempFileManager] = None,
     ):
         """Initialize batch fitting orchestrator.
 
@@ -352,6 +403,9 @@ class BatchFittingOrchestrator:
             sammy_executable: Path to SAMMY binary
             n_workers: Number of parallel workers (default: 4)
             resolution_file: Optional path to resolution function file
+            temp_manager: Optional TempFileManager for controlling workspace
+                locations and cleanup policy. If None, uses system temp directory
+                with immediate cleanup (original behavior).
 
         Raises:
             FileNotFoundError: If SAMMY executable or resolution file doesn't exist
@@ -367,6 +421,7 @@ class BatchFittingOrchestrator:
         self.sammy_executable = sammy_executable
         self.n_workers = n_workers
         self.resolution_file = resolution_file
+        self.temp_manager = temp_manager
 
     def fit_pixels(
         self,
@@ -467,7 +522,13 @@ class BatchFittingOrchestrator:
 
         # Execute remaining pixels in parallel
         if remaining_pixels:
-            with tempfile.TemporaryDirectory(prefix="batch_shared_") as shared_workspace_dir:
+            # Use TempFileManager for shared workspace if provided, otherwise fall back
+            shared_ctx = (
+                self.temp_manager.shared_workspace("batch_shared")
+                if self.temp_manager is not None
+                else tempfile.TemporaryDirectory(prefix="batch_shared_")
+            )
+            with shared_ctx as shared_workspace_dir:
                 shared_json_path, shared_endf_dir = self._prepare_shared_sammy_inputs(Path(shared_workspace_dir))
 
                 with GracefulShutdownHandler() as shutdown_handler:
@@ -619,6 +680,9 @@ class BatchFittingOrchestrator:
         shared_endf_dir: Path,
     ) -> Dict[Future, PixelSpectrum]:
         """Submit pixel fitting jobs to the executor."""
+        temp_base_dir = self.temp_manager.base_dir if self.temp_manager is not None else None
+        cleanup_policy = self.temp_manager.cleanup_policy if self.temp_manager is not None else "immediate"
+
         return {
             executor.submit(
                 _fit_pixel_worker,
@@ -628,6 +692,8 @@ class BatchFittingOrchestrator:
                 self.resolution_file,
                 shared_json_path,
                 shared_endf_dir,
+                temp_base_dir,
+                cleanup_policy,
             ): pixel
             for pixel in pixels
         }

--- a/src/pleiades/imaging/temp_manager.py
+++ b/src/pleiades/imaging/temp_manager.py
@@ -102,7 +102,9 @@ class TempFileManager:
             raise ValueError(f"max_disk_usage_gb must be positive, got {max_disk_usage_gb}")
 
         if base_dir is None:
-            base_dir = Path(tempfile.gettempdir()) / "pleiades_imaging"
+            # Use a unique directory per manager instance to avoid cross-run
+            # collisions and stale directory reuse after crashes.
+            base_dir = Path(tempfile.mkdtemp(prefix="pleiades_imaging_"))
         self.base_dir = Path(base_dir)
         self.max_disk_usage_gb = max_disk_usage_gb
         self.cleanup_policy = cleanup_policy
@@ -137,6 +139,8 @@ class TempFileManager:
             raise ValueError("job_id must not be empty")
         if "/" in job_id or "\\" in job_id:
             raise ValueError(f"job_id must not contain path separators, got {job_id!r}")
+        if job_id in (".", "..") or Path(job_id).parts != (job_id,):
+            raise ValueError(f"job_id must be a single safe path component, got {job_id!r}")
 
         # Ensure base_dir exists before checking disk space
         self.base_dir.mkdir(parents=True, exist_ok=True)
@@ -155,7 +159,10 @@ class TempFileManager:
             yield workspace
         finally:
             if self.cleanup_policy == "immediate":
-                shutil.rmtree(workspace, ignore_errors=True)
+                try:
+                    shutil.rmtree(workspace)
+                except Exception:
+                    logger.warning(f"Immediate cleanup failed for workspace: {workspace}")
                 with self._lock:
                     if workspace in self._active_workspaces:
                         self._active_workspaces.remove(workspace)
@@ -180,6 +187,8 @@ class TempFileManager:
         """
         if not name:
             raise ValueError("name must not be empty")
+        if name in (".", "..") or Path(name).parts != (name,):
+            raise ValueError(f"name must be a single safe path component, got {name!r}")
 
         workspace = self.base_dir / name
         workspace.mkdir(parents=True, exist_ok=True)
@@ -259,6 +268,14 @@ class TempFileManager:
             self._active_workspaces.clear()
 
         return count
+
+    @property
+    def initial_free_gb(self) -> Optional[float]:
+        """Free disk space (GB) recorded when the context manager was entered.
+
+        Returns None if the context manager has not been entered yet.
+        """
+        return self._initial_free_gb
 
     @property
     def active_workspaces(self) -> List[Path]:

--- a/src/pleiades/imaging/temp_manager.py
+++ b/src/pleiades/imaging/temp_manager.py
@@ -1,0 +1,299 @@
+"""Temporary file management for batch SAMMY execution.
+
+This module provides centralized control over the temporary files generated
+during large-scale 2D imaging fitting (262K+ pixel jobs). It handles
+workspace isolation, disk space monitoring, and configurable cleanup policies.
+"""
+
+import shutil
+import tempfile
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+from pydantic import BaseModel
+
+from pleiades.utils.logger import loguru_logger
+
+logger = loguru_logger.bind(name=__name__)
+
+_VALID_CLEANUP_POLICIES = ("immediate", "batch", "manual")
+_BYTES_PER_GB = 1024**3
+
+
+class DiskUsageInfo(BaseModel):
+    """Disk usage information for monitoring batch job storage.
+
+    Attributes:
+        total_gb: Total disk capacity in GB.
+        used_gb: Currently used disk space in GB.
+        free_gb: Currently free disk space in GB.
+        limit_gb: Configured maximum disk usage limit in GB.
+        base_dir: Base directory being monitored.
+    """
+
+    total_gb: float
+    used_gb: float
+    free_gb: float
+    limit_gb: float
+    base_dir: Path
+
+
+class TempFileManager:
+    """Manage temporary files for batch SAMMY execution.
+
+    Provides workspace isolation, disk monitoring, and cleanup policies
+    for large-scale pixel fitting jobs. Each SAMMY run creates ~7 files in
+    an isolated working directory; with 262K pixels this means managing
+    millions of temporary files.
+
+    Cleanup policies:
+        - ``"immediate"``: Worker cleans up directory after each job completes.
+        - ``"batch"``: Directories persist until ``cleanup_all()`` is called.
+        - ``"manual"``: No automatic cleanup; user is responsible.
+
+    Disk usage enforcement:
+        ``max_disk_usage_gb`` caps how much disk the batch is allowed to consume.
+        The manager records the free space when entering the context manager and
+        refuses new workspaces once the consumed amount (``initial_free - current_free``)
+        exceeds the limit. This is an approximation: other processes consuming disk
+        make the estimate more conservative (safe), while other processes freeing
+        disk make it less conservative.
+
+    Note on thread/process safety:
+        ``active_workspaces`` tracking uses a ``threading.Lock`` and is only valid
+        within the parent process. Subprocess workers (via ``ProcessPoolExecutor``)
+        create directories independently under ``base_dir``; the lock does not
+        protect cross-process access. The orchestrator passes ``base_dir`` and
+        ``cleanup_policy`` as serializable values, not the manager object itself.
+
+    Example:
+        >>> with TempFileManager(base_dir=Path("/fast_ssd/tmp"), cleanup_policy="immediate") as mgr:
+        ...     with mgr.job_workspace("pixel_10_20") as ws:
+        ...         run_sammy_in(ws)
+        ...     # workspace cleaned up here (immediate policy)
+    """
+
+    def __init__(
+        self,
+        base_dir: Optional[Path] = None,
+        max_disk_usage_gb: float = 50.0,
+        cleanup_policy: str = "immediate",
+    ):
+        """Initialize the temporary file manager.
+
+        Args:
+            base_dir: Root directory for all workspaces. If None, creates a
+                subdirectory under the system temp directory.
+            max_disk_usage_gb: Maximum disk space (in GB) the batch may consume.
+                Enforced by comparing free space at context entry vs. current free
+                space. ``job_workspace()`` raises ``OSError`` when the consumed
+                amount exceeds this limit or when free space is critically low.
+            cleanup_policy: One of ``"immediate"``, ``"batch"``, ``"manual"``.
+
+        Raises:
+            ValueError: If cleanup_policy is not one of the valid options, or
+                max_disk_usage_gb is not positive.
+        """
+        if cleanup_policy not in _VALID_CLEANUP_POLICIES:
+            raise ValueError(f"cleanup_policy must be one of {_VALID_CLEANUP_POLICIES}, got {cleanup_policy!r}")
+        if max_disk_usage_gb <= 0:
+            raise ValueError(f"max_disk_usage_gb must be positive, got {max_disk_usage_gb}")
+
+        if base_dir is None:
+            base_dir = Path(tempfile.gettempdir()) / "pleiades_imaging"
+        self.base_dir = Path(base_dir)
+        self.max_disk_usage_gb = max_disk_usage_gb
+        self.cleanup_policy = cleanup_policy
+
+        self._active_workspaces: List[Path] = []
+        self._lock = threading.Lock()
+        self._initial_free_gb: Optional[float] = None
+
+    @contextmanager
+    def job_workspace(self, job_id: str) -> Iterator[Path]:
+        """Create an isolated workspace directory for a single SAMMY job.
+
+        The directory is created under ``base_dir`` using the ``job_id`` as the
+        directory name. Cleanup behavior depends on the configured policy.
+
+        Note: The disk space check and directory creation are not atomic (TOCTOU).
+        In high-concurrency scenarios, disk may fill between the check and mkdir.
+        This is inherent to the two-step pattern and considered acceptable.
+
+        Args:
+            job_id: Unique identifier for this job (used as directory name).
+                Must not be empty or contain path separators.
+
+        Yields:
+            Path to the created workspace directory.
+
+        Raises:
+            ValueError: If job_id is empty or contains path separators.
+            OSError: If disk space is insufficient or usage limit exceeded.
+        """
+        if not job_id:
+            raise ValueError("job_id must not be empty")
+        if "/" in job_id or "\\" in job_id:
+            raise ValueError(f"job_id must not contain path separators, got {job_id!r}")
+
+        # Ensure base_dir exists before checking disk space
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+        if not self.check_disk_space():
+            info = self._safe_disk_info_message()
+            raise OSError(f"Insufficient disk space or usage limit exceeded: {info}")
+
+        workspace = self.base_dir / job_id
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        with self._lock:
+            self._active_workspaces.append(workspace)
+
+        try:
+            yield workspace
+        finally:
+            if self.cleanup_policy == "immediate":
+                shutil.rmtree(workspace, ignore_errors=True)
+                with self._lock:
+                    if workspace in self._active_workspaces:
+                        self._active_workspaces.remove(workspace)
+
+    @contextmanager
+    def shared_workspace(self, name: str = "shared") -> Iterator[Path]:
+        """Create a shared workspace for batch-wide resources.
+
+        Shared workspaces hold resources used across all workers (e.g., JSON
+        config, ENDF files). They are **always** cleaned up on context exit
+        regardless of cleanup policy, since shared resources are only needed
+        while the batch run is active.
+
+        Args:
+            name: Name for the shared workspace directory.
+
+        Yields:
+            Path to the created shared workspace directory.
+
+        Raises:
+            ValueError: If name is empty.
+        """
+        if not name:
+            raise ValueError("name must not be empty")
+
+        workspace = self.base_dir / name
+        workspace.mkdir(parents=True, exist_ok=True)
+
+        try:
+            yield workspace
+        finally:
+            shutil.rmtree(workspace, ignore_errors=True)
+
+    def check_disk_space(self, required_gb: float = 0.1) -> bool:
+        """Check whether sufficient disk space is available.
+
+        Checks two conditions:
+        1. Free space on the filesystem >= ``required_gb``.
+        2. If usage tracking is active (context manager entered), the consumed
+           disk space (``initial_free - current_free``) does not exceed
+           ``max_disk_usage_gb``.
+
+        Args:
+            required_gb: Minimum free space required in GB (default: 0.1 GB).
+
+        Returns:
+            True if both conditions are met, False otherwise.
+            Never raises exceptions — returns False on any error.
+        """
+        try:
+            usage = shutil.disk_usage(self.base_dir)
+            free_gb = usage.free / _BYTES_PER_GB
+
+            if free_gb < required_gb:
+                return False
+
+            # Enforce max_disk_usage_gb when usage tracking is active
+            if self._initial_free_gb is not None:
+                consumed_gb = self._initial_free_gb - free_gb
+                if consumed_gb > self.max_disk_usage_gb:
+                    return False
+
+            return True
+        except Exception:
+            return False
+
+    def get_disk_usage_info(self) -> DiskUsageInfo:
+        """Get current disk usage information.
+
+        Returns:
+            DiskUsageInfo with current disk statistics and configured limits.
+        """
+        usage = shutil.disk_usage(self.base_dir)
+        return DiskUsageInfo(
+            total_gb=usage.total / _BYTES_PER_GB,
+            used_gb=usage.used / _BYTES_PER_GB,
+            free_gb=usage.free / _BYTES_PER_GB,
+            limit_gb=self.max_disk_usage_gb,
+            base_dir=self.base_dir,
+        )
+
+    def cleanup_all(self) -> int:
+        """Remove all directories under base_dir.
+
+        Returns:
+            Number of directories successfully removed.
+        """
+        count = 0
+        if not self.base_dir.exists():
+            return count
+
+        for child in list(self.base_dir.iterdir()):
+            if child.is_dir():
+                try:
+                    shutil.rmtree(child)
+                    count += 1
+                except Exception:
+                    logger.warning(f"Failed to remove workspace: {child}")
+
+        with self._lock:
+            self._active_workspaces.clear()
+
+        return count
+
+    @property
+    def active_workspaces(self) -> List[Path]:
+        """List of currently active (not yet cleaned up) workspace directories.
+
+        Returns a copy so callers cannot modify internal state.
+        """
+        with self._lock:
+            return list(self._active_workspaces)
+
+    def _safe_disk_info_message(self) -> str:
+        """Build a safe disk info string for error messages, handling failures."""
+        try:
+            usage = shutil.disk_usage(self.base_dir)
+            free_gb = usage.free / _BYTES_PER_GB
+            msg = f"{free_gb:.2f} GB free"
+            if self._initial_free_gb is not None:
+                consumed = self._initial_free_gb - free_gb
+                msg += f", {consumed:.2f} GB consumed (limit: {self.max_disk_usage_gb} GB)"
+            return msg
+        except Exception:
+            return f"unable to read disk usage for {self.base_dir}"
+
+    def __enter__(self) -> "TempFileManager":
+        """Create base_dir and record initial free space for usage tracking."""
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self._initial_free_gb = shutil.disk_usage(self.base_dir).free / _BYTES_PER_GB
+        except Exception:
+            self._initial_free_gb = None
+        return self
+
+    def __exit__(self, *args) -> None:
+        """Clean up on exit. For non-manual policies, remove all workspaces and base_dir."""
+        if self.cleanup_policy != "manual":
+            self.cleanup_all()
+            if self.base_dir.exists():
+                shutil.rmtree(self.base_dir, ignore_errors=True)

--- a/tests/unit/pleiades/imaging/test_temp_manager.py
+++ b/tests/unit/pleiades/imaging/test_temp_manager.py
@@ -101,6 +101,29 @@ class TestInit:
         manager = TempFileManager(base_dir=tmp_path, max_disk_usage_gb=0.001, cleanup_policy="immediate")
         assert manager is not None
 
+    def test_default_base_dir_is_unique_per_instance(self):
+        """Each manager instance with default base_dir gets a unique directory."""
+        m1 = TempFileManager(base_dir=None, cleanup_policy="immediate")
+        m2 = TempFileManager(base_dir=None, cleanup_policy="immediate")
+        assert m1.base_dir != m2.base_dir
+        # Clean up the mkdtemp directories
+        import shutil
+
+        shutil.rmtree(m1.base_dir, ignore_errors=True)
+        shutil.rmtree(m2.base_dir, ignore_errors=True)
+
+    def test_initial_free_gb_none_before_context(self, tmp_path):
+        """initial_free_gb property is None before entering context."""
+        manager = TempFileManager(base_dir=tmp_path / "ws", cleanup_policy="immediate")
+        assert manager.initial_free_gb is None
+
+    def test_initial_free_gb_set_after_context_entry(self, tmp_path):
+        """initial_free_gb property is set to a float after entering context."""
+        manager = TempFileManager(base_dir=tmp_path / "ws", cleanup_policy="immediate")
+        with manager:
+            assert isinstance(manager.initial_free_gb, float)
+            assert manager.initial_free_gb > 0
+
 
 # ===========================================================================
 # TestJobWorkspace
@@ -392,9 +415,9 @@ class TestDiskMonitoring:
         manager = TempFileManager(base_dir=tmp_path / "ws", max_disk_usage_gb=1.0, cleanup_policy="immediate")
 
         with manager:
-            # At entry, _initial_free_gb was recorded from the real filesystem.
+            # At entry, initial_free_gb was recorded from the real filesystem.
             # Now mock disk_usage to simulate that 2 GB has been consumed since entry.
-            initial_free = manager._initial_free_gb
+            initial_free = manager.initial_free_gb
             assert initial_free is not None
 
             # Simulate: 2 GB consumed (more than the 1 GB limit)
@@ -590,6 +613,34 @@ class TestEdgeCases:
         with manager_immediate:
             with pytest.raises(ValueError, match="path separators"):
                 with manager_immediate.job_workspace("job/sub/path"):
+                    pass  # pragma: no cover
+
+    def test_job_id_dot_dot_rejected(self, manager_immediate):
+        """job_id '..' is rejected to prevent directory traversal."""
+        with manager_immediate:
+            with pytest.raises(ValueError, match="single safe path component"):
+                with manager_immediate.job_workspace(".."):
+                    pass  # pragma: no cover
+
+    def test_job_id_single_dot_rejected(self, manager_immediate):
+        """job_id '.' is rejected to prevent directory traversal."""
+        with manager_immediate:
+            with pytest.raises(ValueError, match="single safe path component"):
+                with manager_immediate.job_workspace("."):
+                    pass  # pragma: no cover
+
+    def test_shared_workspace_dot_dot_rejected(self, manager_immediate):
+        """shared_workspace name '..' is rejected to prevent directory traversal."""
+        with manager_immediate:
+            with pytest.raises(ValueError, match="single safe path component"):
+                with manager_immediate.shared_workspace(".."):
+                    pass  # pragma: no cover
+
+    def test_shared_workspace_single_dot_rejected(self, manager_immediate):
+        """shared_workspace name '.' is rejected to prevent directory traversal."""
+        with manager_immediate:
+            with pytest.raises(ValueError, match="single safe path component"):
+                with manager_immediate.shared_workspace("."):
                     pass  # pragma: no cover
 
     def test_very_long_job_id(self, manager_immediate):
@@ -1011,6 +1062,41 @@ class TestOrchestratorIntegration:
         assert paths[1].name == "pixel_1_1_a1"
         assert paths[2].name == "pixel_1_1_a2"
 
+    def test_worker_cleans_stale_workspace_before_reuse(self, tmp_path):
+        """Worker removes pre-existing stale workspace before creating a new one (C8)."""
+        from unittest.mock import MagicMock, patch
+
+        from pleiades.imaging.orchestrator import _fit_pixel_worker
+
+        pixel = _make_pixel(2, 4)
+        config = _make_imaging_config()
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+        base_dir = tmp_path / "managed_ws"
+        base_dir.mkdir()
+
+        # Pre-create a stale workspace with leftover data
+        stale_dir = base_dir / "pixel_2_4_a0"
+        stale_dir.mkdir()
+        stale_file = stale_dir / "old_output.dat"
+        stale_file.write_text("stale data from crashed run", encoding="utf-8")
+
+        mock_result = MagicMock()
+        mock_result.row = 2
+        mock_result.col = 4
+        mock_result.success = False
+        mock_result.error_message = "mock"
+
+        with patch("pleiades.imaging.orchestrator._fit_pixel_worker_impl") as mock_impl:
+            mock_impl.return_value = mock_result
+            _fit_pixel_worker(pixel, config, sammy_exe, temp_base_dir=base_dir, cleanup_policy="batch", attempt_id=0)
+
+            # The workspace should exist but the stale file should be gone
+            call_args = mock_impl.call_args[0]
+            temp_path_arg = call_args[6]
+            assert temp_path_arg.exists()
+            assert not (temp_path_arg / "old_output.dat").exists()
+
     def test_submit_pixels_passes_attempt_round_and_disk_params(self, tmp_path):
         """_submit_pixels passes attempt_round, max_disk_usage_gb, initial_free_gb (P1+P2)."""
         from concurrent.futures import ProcessPoolExecutor
@@ -1084,8 +1170,8 @@ class TestOrchestratorIntegration:
         config = _make_imaging_config()
         orch = BatchFittingOrchestrator(imaging_config=config, sammy_executable=sammy_exe, temp_manager=mgr)
 
-        # Before fit_pixels, _initial_free_gb should be None
-        assert mgr._initial_free_gb is None
+        # Before fit_pixels, initial_free_gb should be None
+        assert mgr.initial_free_gb is None
 
         pixel = _make_pixel(0, 0)
 
@@ -1115,9 +1201,9 @@ class TestOrchestratorIntegration:
                 mock_executor.submit.side_effect = submit_side_effect
                 orch.fit_pixels([pixel])
 
-        # After fit_pixels, _initial_free_gb should have been set by __enter__
-        # Note: __exit__ already ran, but _initial_free_gb persists on the object
-        assert mgr._initial_free_gb is not None
+        # After fit_pixels, initial_free_gb should have been set by __enter__
+        # Note: __exit__ already ran, but initial_free_gb persists on the object
+        assert mgr.initial_free_gb is not None
 
     def test_fit_pixels_cleans_up_batch_workspaces(self, tmp_path):
         """fit_pixels cleans up batch workspaces on exit for non-manual policies."""

--- a/tests/unit/pleiades/imaging/test_temp_manager.py
+++ b/tests/unit/pleiades/imaging/test_temp_manager.py
@@ -1069,6 +1069,103 @@ class TestOrchestratorIntegration:
         assert args[10] is None  # max_disk_usage_gb
         assert args[11] is None  # initial_free_gb
 
+    def test_fit_pixels_enters_temp_manager_context(self, tmp_path):
+        """fit_pixels enters TempFileManager context so _initial_free_gb is set for disk cap."""
+        from concurrent.futures import Future
+        from unittest.mock import MagicMock, patch
+
+        from pleiades.imaging.models import PixelFitResult
+        from pleiades.imaging.orchestrator import BatchFittingOrchestrator
+
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        mgr = TempFileManager(base_dir=tmp_path / "ws", max_disk_usage_gb=25.0, cleanup_policy="batch")
+        config = _make_imaging_config()
+        orch = BatchFittingOrchestrator(imaging_config=config, sammy_executable=sammy_exe, temp_manager=mgr)
+
+        # Before fit_pixels, _initial_free_gb should be None
+        assert mgr._initial_free_gb is None
+
+        pixel = _make_pixel(0, 0)
+
+        # Use real Future objects so as_completed works
+        def submit_side_effect(fn, px, *args, **kwargs):
+            future = Future()
+            future.set_result(
+                PixelFitResult(row=px.row, col=px.col, fit_results=None, success=False, error_message="mock")
+            )
+            return future
+
+        mock_json_instance = MagicMock()
+
+        def create_json_side_effect(isotopes, abundances, working_dir):
+            working_dir.mkdir(parents=True, exist_ok=True)
+            shared_json = working_dir / "config.json"
+            shared_json.write_text("{}", encoding="utf-8")
+            return shared_json
+
+        mock_json_instance.create_json_config.side_effect = create_json_side_effect
+
+        with patch("pleiades.imaging.orchestrator.JsonManager") as mock_json_cls:
+            mock_json_cls.return_value = mock_json_instance
+            with patch("pleiades.imaging.orchestrator.ProcessPoolExecutor") as mock_pool_cls:
+                mock_executor = MagicMock()
+                mock_pool_cls.return_value = mock_executor
+                mock_executor.submit.side_effect = submit_side_effect
+                orch.fit_pixels([pixel])
+
+        # After fit_pixels, _initial_free_gb should have been set by __enter__
+        # Note: __exit__ already ran, but _initial_free_gb persists on the object
+        assert mgr._initial_free_gb is not None
+
+    def test_fit_pixels_cleans_up_batch_workspaces(self, tmp_path):
+        """fit_pixels cleans up batch workspaces on exit for non-manual policies."""
+        from concurrent.futures import Future
+        from unittest.mock import MagicMock, patch
+
+        from pleiades.imaging.models import PixelFitResult
+        from pleiades.imaging.orchestrator import BatchFittingOrchestrator
+
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        base_dir = tmp_path / "ws"
+        mgr = TempFileManager(base_dir=base_dir, max_disk_usage_gb=25.0, cleanup_policy="batch")
+        config = _make_imaging_config()
+        orch = BatchFittingOrchestrator(imaging_config=config, sammy_executable=sammy_exe, temp_manager=mgr)
+
+        pixel = _make_pixel(0, 0)
+
+        def submit_side_effect(fn, px, *args, **kwargs):
+            future = Future()
+            future.set_result(
+                PixelFitResult(row=px.row, col=px.col, fit_results=None, success=False, error_message="mock")
+            )
+            return future
+
+        mock_json_instance = MagicMock()
+
+        def create_json_side_effect(isotopes, abundances, working_dir):
+            working_dir.mkdir(parents=True, exist_ok=True)
+            shared_json = working_dir / "config.json"
+            shared_json.write_text("{}", encoding="utf-8")
+            return shared_json
+
+        mock_json_instance.create_json_config.side_effect = create_json_side_effect
+
+        with patch("pleiades.imaging.orchestrator.JsonManager") as mock_json_cls:
+            mock_json_cls.return_value = mock_json_instance
+            with patch("pleiades.imaging.orchestrator.ProcessPoolExecutor") as mock_pool_cls:
+                mock_executor = MagicMock()
+                mock_pool_cls.return_value = mock_executor
+                mock_executor.submit.side_effect = submit_side_effect
+                orch.fit_pixels([pixel])
+
+        # After fit_pixels, base_dir should be cleaned up for batch policy
+        # (TempFileManager.__exit__ removes base_dir for non-manual policies)
+        assert not base_dir.exists()
+
 
 # ===========================================================================
 # TestCheckWorkerDiskSpace

--- a/tests/unit/pleiades/imaging/test_temp_manager.py
+++ b/tests/unit/pleiades/imaging/test_temp_manager.py
@@ -949,6 +949,217 @@ class TestOrchestratorIntegration:
             temp_path_arg = call_args[6]
             assert temp_path_arg is None
 
+    def test_worker_attempt_id_in_workspace_name(self, tmp_path):
+        """attempt_id is included in workspace directory name to prevent retry collisions (P1)."""
+        from unittest.mock import MagicMock, patch
+
+        from pleiades.imaging.orchestrator import _fit_pixel_worker
+
+        pixel = _make_pixel(5, 9)
+        config = _make_imaging_config()
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+        base_dir = tmp_path / "managed_ws"
+        base_dir.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.row = 5
+        mock_result.col = 9
+        mock_result.success = False
+        mock_result.error_message = "mock"
+
+        with patch("pleiades.imaging.orchestrator._fit_pixel_worker_impl") as mock_impl:
+            mock_impl.return_value = mock_result
+            _fit_pixel_worker(pixel, config, sammy_exe, temp_base_dir=base_dir, cleanup_policy="batch", attempt_id=2)
+
+            call_args = mock_impl.call_args[0]
+            temp_path_arg = call_args[6]
+            assert temp_path_arg is not None
+            assert temp_path_arg.name == "pixel_5_9_a2"
+
+    def test_worker_different_attempts_get_different_dirs(self, tmp_path):
+        """Different attempt_id values produce different workspace directories (P1)."""
+        from unittest.mock import MagicMock, patch
+
+        from pleiades.imaging.orchestrator import _fit_pixel_worker
+
+        pixel = _make_pixel(1, 1)
+        config = _make_imaging_config()
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+        base_dir = tmp_path / "managed_ws"
+        base_dir.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.row = 1
+        mock_result.col = 1
+        mock_result.success = False
+        mock_result.error_message = "mock"
+
+        paths = []
+        for attempt in range(3):
+            with patch("pleiades.imaging.orchestrator._fit_pixel_worker_impl") as mock_impl:
+                mock_impl.return_value = mock_result
+                _fit_pixel_worker(
+                    pixel, config, sammy_exe, temp_base_dir=base_dir, cleanup_policy="batch", attempt_id=attempt
+                )
+                paths.append(mock_impl.call_args[0][6])
+
+        # All three paths should be unique
+        assert len(set(str(p) for p in paths)) == 3
+        assert paths[0].name == "pixel_1_1_a0"
+        assert paths[1].name == "pixel_1_1_a1"
+        assert paths[2].name == "pixel_1_1_a2"
+
+    def test_submit_pixels_passes_attempt_round_and_disk_params(self, tmp_path):
+        """_submit_pixels passes attempt_round, max_disk_usage_gb, initial_free_gb (P1+P2)."""
+        from concurrent.futures import ProcessPoolExecutor
+        from unittest.mock import MagicMock
+
+        from pleiades.imaging.orchestrator import BatchFittingOrchestrator
+
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        mgr = TempFileManager(base_dir=tmp_path / "ws", max_disk_usage_gb=25.0, cleanup_policy="batch")
+        config = _make_imaging_config()
+
+        orch = BatchFittingOrchestrator(imaging_config=config, sammy_executable=sammy_exe, temp_manager=mgr)
+
+        # Simulate entering the context manager to set _initial_free_gb
+        with mgr:
+            mock_executor = MagicMock(spec=ProcessPoolExecutor)
+            mock_future = MagicMock()
+            mock_executor.submit.return_value = mock_future
+
+            pixel = _make_pixel(0, 0)
+            orch._submit_pixels(mock_executor, [pixel], Path("/json"), Path("/endf"), attempt_round=3)
+
+            call_args = mock_executor.submit.call_args
+            args = call_args[0]
+            # args: (fn, pixel, config, exe, resolution, json, endf, base_dir, policy,
+            #        attempt_round, max_disk_usage_gb, initial_free_gb)
+            assert args[9] == 3  # attempt_round
+            assert args[10] == 25.0  # max_disk_usage_gb
+            assert isinstance(args[11], float)  # initial_free_gb (recorded from real disk)
+
+    def test_submit_pixels_without_temp_manager_passes_none_for_disk_params(self, tmp_path):
+        """Without temp_manager, disk params are None (P2)."""
+        from concurrent.futures import ProcessPoolExecutor
+        from unittest.mock import MagicMock
+
+        from pleiades.imaging.orchestrator import BatchFittingOrchestrator
+
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        config = _make_imaging_config()
+        orch = BatchFittingOrchestrator(imaging_config=config, sammy_executable=sammy_exe)
+
+        mock_executor = MagicMock(spec=ProcessPoolExecutor)
+        mock_future = MagicMock()
+        mock_executor.submit.return_value = mock_future
+
+        pixel = _make_pixel(0, 0)
+        orch._submit_pixels(mock_executor, [pixel], Path("/json"), Path("/endf"))
+
+        call_args = mock_executor.submit.call_args
+        args = call_args[0]
+        assert args[9] == 0  # attempt_round defaults to 0
+        assert args[10] is None  # max_disk_usage_gb
+        assert args[11] is None  # initial_free_gb
+
+
+# ===========================================================================
+# TestCheckWorkerDiskSpace
+# ===========================================================================
+
+
+class TestCheckWorkerDiskSpace:
+    """Tests for _check_worker_disk_space function (P2: worker-side disk enforcement)."""
+
+    def test_returns_none_when_space_sufficient(self, tmp_path):
+        """Returns None (no error) when disk has enough space."""
+        from pleiades.imaging.orchestrator import _check_worker_disk_space
+
+        result = _check_worker_disk_space(tmp_path, max_disk_usage_gb=50.0, initial_free_gb=100.0)
+        assert result is None
+
+    def test_returns_error_when_free_space_too_low(self, tmp_path):
+        """Returns error message when free space is below required_gb."""
+        from pleiades.imaging.orchestrator import _check_worker_disk_space
+
+        mock_usage = _DiskUsage(total=100 * _BYTES_PER_GB, used=99 * _BYTES_PER_GB, free=0)
+        with patch("shutil.disk_usage", return_value=mock_usage):
+            result = _check_worker_disk_space(tmp_path, max_disk_usage_gb=50.0, initial_free_gb=100.0)
+            assert result is not None
+            assert "free" in result
+
+    def test_returns_error_when_consumed_exceeds_limit(self, tmp_path):
+        """Returns error when consumed space exceeds max_disk_usage_gb."""
+        from pleiades.imaging.orchestrator import _check_worker_disk_space
+
+        # Simulate: initial_free was 100 GB, now 90 GB free → consumed 10 GB, limit 5 GB
+        mock_usage = _DiskUsage(total=200 * _BYTES_PER_GB, used=110 * _BYTES_PER_GB, free=90 * _BYTES_PER_GB)
+        with patch("shutil.disk_usage", return_value=mock_usage):
+            result = _check_worker_disk_space(tmp_path, max_disk_usage_gb=5.0, initial_free_gb=100.0, required_gb=0.1)
+            assert result is not None
+            assert "consumed" in result
+            assert "limit" in result
+
+    def test_returns_none_when_consumed_within_limit(self, tmp_path):
+        """Returns None when consumed space is within the limit."""
+        from pleiades.imaging.orchestrator import _check_worker_disk_space
+
+        # Simulate: initial_free was 100 GB, now 97 GB free → consumed 3 GB, limit 5 GB
+        mock_usage = _DiskUsage(total=200 * _BYTES_PER_GB, used=103 * _BYTES_PER_GB, free=97 * _BYTES_PER_GB)
+        with patch("shutil.disk_usage", return_value=mock_usage):
+            result = _check_worker_disk_space(tmp_path, max_disk_usage_gb=5.0, initial_free_gb=100.0, required_gb=0.1)
+            assert result is None
+
+    def test_skips_consumed_check_when_params_none(self, tmp_path):
+        """When max_disk_usage_gb or initial_free_gb is None, skips consumed-space check."""
+        from pleiades.imaging.orchestrator import _check_worker_disk_space
+
+        # With None params, only the free-space check runs
+        result = _check_worker_disk_space(tmp_path, max_disk_usage_gb=None, initial_free_gb=None)
+        assert result is None
+
+    def test_returns_error_on_disk_usage_exception(self):
+        """Returns error message when shutil.disk_usage raises an exception."""
+        from pleiades.imaging.orchestrator import _check_worker_disk_space
+
+        with patch("shutil.disk_usage", side_effect=OSError("disk gone")):
+            result = _check_worker_disk_space(Path("/nonexistent"), max_disk_usage_gb=50.0, initial_free_gb=100.0)
+            assert result is not None
+            assert "disk check failed" in result
+
+    def test_worker_returns_failure_on_disk_space_check(self, tmp_path):
+        """_fit_pixel_worker returns PixelFitResult(success=False) when disk check fails (P2)."""
+        from pleiades.imaging.orchestrator import _fit_pixel_worker
+
+        pixel = _make_pixel(2, 3)
+        config = _make_imaging_config()
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+        base_dir = tmp_path / "managed_ws"
+        base_dir.mkdir()
+
+        # Simulate disk full
+        mock_usage = _DiskUsage(total=100 * _BYTES_PER_GB, used=99 * _BYTES_PER_GB, free=0)
+        with patch("shutil.disk_usage", return_value=mock_usage):
+            result = _fit_pixel_worker(
+                pixel,
+                config,
+                sammy_exe,
+                temp_base_dir=base_dir,
+                cleanup_policy="batch",
+                max_disk_usage_gb=50.0,
+                initial_free_gb=100.0,
+            )
+            assert result.success is False
+            assert "Disk space check failed" in result.error_message
+
 
 # ---------------------------------------------------------------------------
 # Helpers for integration tests

--- a/tests/unit/pleiades/imaging/test_temp_manager.py
+++ b/tests/unit/pleiades/imaging/test_temp_manager.py
@@ -1,0 +1,985 @@
+"""Unit tests for TempFileManager and DiskUsageInfo.
+
+These tests are written BEFORE implementation (TDD). They exercise:
+  - TempFileManager: temporary file lifecycle for batch SAMMY execution
+  - DiskUsageInfo: pydantic model for disk usage reporting
+  - Context manager protocol for both job and shared workspaces
+  - Disk space monitoring and enforcement
+  - Cleanup policies: immediate, batch, manual
+
+Tests use pytest tmp_path fixture for all disk operations to avoid
+polluting the real filesystem.
+"""
+
+import threading
+from collections import namedtuple
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pleiades.imaging.temp_manager import _BYTES_PER_GB, DiskUsageInfo, TempFileManager
+
+# Named tuple matching the return type of shutil.disk_usage
+_DiskUsage = namedtuple("usage", ["total", "used", "free"])
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager_immediate(tmp_path):
+    """Create a TempFileManager with immediate cleanup policy."""
+    return TempFileManager(base_dir=tmp_path / "workspaces", max_disk_usage_gb=50.0, cleanup_policy="immediate")
+
+
+@pytest.fixture
+def manager_batch(tmp_path):
+    """Create a TempFileManager with batch cleanup policy."""
+    return TempFileManager(base_dir=tmp_path / "workspaces", max_disk_usage_gb=50.0, cleanup_policy="batch")
+
+
+@pytest.fixture
+def manager_manual(tmp_path):
+    """Create a TempFileManager with manual cleanup policy."""
+    return TempFileManager(base_dir=tmp_path / "workspaces", max_disk_usage_gb=50.0, cleanup_policy="manual")
+
+
+# ===========================================================================
+# TestInit
+# ===========================================================================
+
+
+class TestInit:
+    """Tests for TempFileManager initialization and validation."""
+
+    def test_default_base_dir_uses_system_temp(self):
+        """When base_dir is None, a directory under the system temp directory is used."""
+        manager = TempFileManager(base_dir=None, cleanup_policy="immediate")
+        import tempfile
+
+        system_temp = Path(tempfile.gettempdir())
+        assert manager.base_dir is not None
+        # The base_dir should be under the system temp directory
+        assert str(manager.base_dir).startswith(str(system_temp))
+
+    def test_custom_base_dir(self, tmp_path):
+        """Custom base_dir is stored correctly."""
+        custom_dir = tmp_path / "my_workspace"
+        manager = TempFileManager(base_dir=custom_dir, cleanup_policy="immediate")
+        assert manager.base_dir == custom_dir
+
+    def test_invalid_cleanup_policy_raises_value_error(self, tmp_path):
+        """Invalid cleanup_policy string raises ValueError."""
+        with pytest.raises(ValueError, match="cleanup_policy"):
+            TempFileManager(base_dir=tmp_path, cleanup_policy="invalid_policy")
+
+    def test_empty_cleanup_policy_raises_value_error(self, tmp_path):
+        """Empty cleanup_policy string raises ValueError."""
+        with pytest.raises(ValueError, match="cleanup_policy"):
+            TempFileManager(base_dir=tmp_path, cleanup_policy="")
+
+    def test_non_positive_max_disk_usage_raises_value_error(self, tmp_path):
+        """Negative max_disk_usage_gb raises ValueError."""
+        with pytest.raises(ValueError, match="max_disk_usage_gb"):
+            TempFileManager(base_dir=tmp_path, max_disk_usage_gb=-1.0, cleanup_policy="immediate")
+
+    def test_zero_max_disk_usage_raises_value_error(self, tmp_path):
+        """Zero max_disk_usage_gb raises ValueError."""
+        with pytest.raises(ValueError, match="max_disk_usage_gb"):
+            TempFileManager(base_dir=tmp_path, max_disk_usage_gb=0.0, cleanup_policy="immediate")
+
+    def test_valid_cleanup_policies_accepted(self, tmp_path):
+        """All three valid cleanup policies are accepted without error."""
+        for policy in ("immediate", "batch", "manual"):
+            manager = TempFileManager(base_dir=tmp_path / policy, cleanup_policy=policy)
+            assert manager is not None
+
+    def test_positive_max_disk_usage_accepted(self, tmp_path):
+        """Positive max_disk_usage_gb values are accepted."""
+        manager = TempFileManager(base_dir=tmp_path, max_disk_usage_gb=0.001, cleanup_policy="immediate")
+        assert manager is not None
+
+
+# ===========================================================================
+# TestJobWorkspace
+# ===========================================================================
+
+
+class TestJobWorkspace:
+    """Tests for job_workspace context manager."""
+
+    def test_creates_directory_and_yields_path(self, manager_immediate):
+        """job_workspace creates a directory and yields a valid Path."""
+        with manager_immediate:
+            with manager_immediate.job_workspace("job_001") as ws:
+                assert isinstance(ws, Path)
+                assert ws.exists()
+                assert ws.is_dir()
+
+    def test_directory_name_matches_job_id(self, manager_immediate):
+        """Created directory name should incorporate the job_id."""
+        with manager_immediate:
+            with manager_immediate.job_workspace("job_001") as ws:
+                assert "job_001" in ws.name
+
+    def test_immediate_cleanup_removes_directory(self, manager_immediate):
+        """With immediate policy, directory is removed after context exit."""
+        with manager_immediate:
+            with manager_immediate.job_workspace("job_001") as ws:
+                workspace_path = ws
+                assert ws.exists()
+            # After context exit, directory should be gone
+            assert not workspace_path.exists()
+
+    def test_batch_cleanup_preserves_directory(self, manager_batch):
+        """With batch policy, directory persists after context exit."""
+        with manager_batch:
+            with manager_batch.job_workspace("job_001") as ws:
+                workspace_path = ws
+                assert ws.exists()
+            # After context exit, directory should still exist
+            assert workspace_path.exists()
+
+    def test_manual_cleanup_preserves_directory(self, manager_manual):
+        """With manual policy, directory persists after context exit."""
+        with manager_manual:
+            with manager_manual.job_workspace("job_001") as ws:
+                workspace_path = ws
+                assert ws.exists()
+            # After context exit, directory should still exist
+            assert workspace_path.exists()
+
+    def test_empty_job_id_raises_value_error(self, manager_immediate):
+        """Empty job_id raises ValueError."""
+        with manager_immediate:
+            with pytest.raises(ValueError, match="job_id"):
+                with manager_immediate.job_workspace(""):
+                    pass  # pragma: no cover
+
+    def test_files_created_inside_workspace_persist_during_context(self, manager_immediate):
+        """Files written inside workspace are accessible during the context."""
+        with manager_immediate:
+            with manager_immediate.job_workspace("job_file_test") as ws:
+                # Write a file
+                test_file = ws / "test_output.dat"
+                test_file.write_text("SAMMY output data\n", encoding="utf-8")
+
+                # Read it back
+                assert test_file.exists()
+                content = test_file.read_text(encoding="utf-8")
+                assert content == "SAMMY output data\n"
+
+    def test_multiple_concurrent_workspaces_do_not_interfere(self, manager_batch):
+        """Multiple workspaces created simultaneously have independent directories."""
+        with manager_batch:
+            with manager_batch.job_workspace("job_A") as ws_a:
+                with manager_batch.job_workspace("job_B") as ws_b:
+                    assert ws_a != ws_b
+                    assert ws_a.exists()
+                    assert ws_b.exists()
+
+                    # Write files in each
+                    (ws_a / "data_a.txt").write_text("A", encoding="utf-8")
+                    (ws_b / "data_b.txt").write_text("B", encoding="utf-8")
+
+                    # Files are isolated
+                    assert (ws_a / "data_a.txt").exists()
+                    assert not (ws_a / "data_b.txt").exists()
+                    assert (ws_b / "data_b.txt").exists()
+                    assert not (ws_b / "data_a.txt").exists()
+
+    def test_tracks_workspace_in_active_workspaces(self, manager_immediate):
+        """Workspace is tracked in active_workspaces during context."""
+        with manager_immediate:
+            assert len(manager_immediate.active_workspaces) == 0
+
+            with manager_immediate.job_workspace("job_tracked") as ws:
+                assert ws in manager_immediate.active_workspaces
+
+    def test_removes_workspace_from_active_after_immediate_cleanup(self, manager_immediate):
+        """With immediate policy, workspace is removed from active_workspaces after exit."""
+        with manager_immediate:
+            with manager_immediate.job_workspace("job_tracked") as ws:
+                assert ws in manager_immediate.active_workspaces
+
+            # After exit, should no longer be tracked
+            assert ws not in manager_immediate.active_workspaces
+            assert len(manager_immediate.active_workspaces) == 0
+
+    def test_workspace_remains_in_active_after_batch_exit(self, manager_batch):
+        """With batch policy, workspace stays in active_workspaces after exit."""
+        with manager_batch:
+            with manager_batch.job_workspace("job_batch") as ws:
+                pass
+
+            # After exit with batch policy, workspace should still be tracked
+            assert ws in manager_batch.active_workspaces
+
+    def test_disk_space_check_failure_raises_os_error(self, tmp_path):
+        """job_workspace raises OSError when disk space check fails."""
+        manager = TempFileManager(base_dir=tmp_path / "ws", max_disk_usage_gb=50.0, cleanup_policy="immediate")
+
+        # Mock shutil.disk_usage to report very low free space
+        mock_usage = _DiskUsage(total=100 * 1024**3, used=99 * 1024**3, free=0)
+        with manager:
+            with patch("shutil.disk_usage", return_value=mock_usage):
+                with pytest.raises(OSError, match="[Dd]isk|[Ss]pace"):
+                    with manager.job_workspace("job_no_space"):
+                        pass  # pragma: no cover
+
+    def test_exception_inside_context_still_triggers_cleanup(self, manager_immediate):
+        """Exception inside job_workspace still triggers directory cleanup (immediate)."""
+        with manager_immediate:
+            workspace_path = None
+            with pytest.raises(RuntimeError, match="deliberate error"):
+                with manager_immediate.job_workspace("job_error") as ws:
+                    workspace_path = ws
+                    raise RuntimeError("deliberate error")
+
+            # Directory should still be cleaned up
+            assert workspace_path is not None
+            assert not workspace_path.exists()
+
+    def test_exception_inside_batch_context_preserves_directory(self, manager_batch):
+        """Exception inside job_workspace with batch policy preserves directory."""
+        with manager_batch:
+            workspace_path = None
+            with pytest.raises(RuntimeError, match="deliberate error"):
+                with manager_batch.job_workspace("job_batch_error") as ws:
+                    workspace_path = ws
+                    raise RuntimeError("deliberate error")
+
+            # Directory should still exist with batch policy
+            assert workspace_path is not None
+            assert workspace_path.exists()
+
+
+# ===========================================================================
+# TestSharedWorkspace
+# ===========================================================================
+
+
+class TestSharedWorkspace:
+    """Tests for shared_workspace context manager."""
+
+    def test_creates_directory_and_yields_path(self, manager_immediate):
+        """shared_workspace creates a directory and yields a valid Path."""
+        with manager_immediate:
+            with manager_immediate.shared_workspace("shared") as ws:
+                assert isinstance(ws, Path)
+                assert ws.exists()
+                assert ws.is_dir()
+
+    def test_always_cleaned_up_immediate_policy(self, manager_immediate):
+        """shared_workspace directory is cleaned up after exit (immediate policy)."""
+        with manager_immediate:
+            with manager_immediate.shared_workspace("shared") as ws:
+                workspace_path = ws
+                assert ws.exists()
+            assert not workspace_path.exists()
+
+    def test_always_cleaned_up_batch_policy(self, manager_batch):
+        """shared_workspace directory is cleaned up after exit (batch policy)."""
+        with manager_batch:
+            with manager_batch.shared_workspace("shared") as ws:
+                workspace_path = ws
+                assert ws.exists()
+            assert not workspace_path.exists()
+
+    def test_always_cleaned_up_manual_policy(self, manager_manual):
+        """shared_workspace directory is cleaned up after exit (manual policy)."""
+        with manager_manual:
+            with manager_manual.shared_workspace("shared") as ws:
+                workspace_path = ws
+                assert ws.exists()
+            assert not workspace_path.exists()
+
+    def test_empty_name_raises_value_error(self, manager_immediate):
+        """Empty name raises ValueError."""
+        with manager_immediate:
+            with pytest.raises(ValueError, match="name"):
+                with manager_immediate.shared_workspace(""):
+                    pass  # pragma: no cover
+
+    def test_custom_name(self, manager_immediate):
+        """shared_workspace uses the provided name."""
+        with manager_immediate:
+            with manager_immediate.shared_workspace("my_shared_resources") as ws:
+                assert "my_shared_resources" in ws.name
+
+
+# ===========================================================================
+# TestDiskMonitoring
+# ===========================================================================
+
+
+class TestDiskMonitoring:
+    """Tests for disk space checking methods."""
+
+    def test_check_disk_space_returns_bool(self, manager_immediate):
+        """check_disk_space returns a boolean value."""
+        with manager_immediate:
+            result = manager_immediate.check_disk_space()
+            assert isinstance(result, bool)
+
+    def test_check_disk_space_with_small_requirement_returns_true(self, manager_immediate):
+        """check_disk_space with a tiny required_gb should return True on any system."""
+        with manager_immediate:
+            assert manager_immediate.check_disk_space(required_gb=0.0001) is True
+
+    def test_check_disk_space_with_very_large_required_gb_returns_false(self, manager_immediate):
+        """check_disk_space with impossibly large required_gb should return False."""
+        with manager_immediate:
+            # 1 exabyte should exceed any real disk
+            assert manager_immediate.check_disk_space(required_gb=1_000_000_000.0) is False
+
+    def test_get_disk_usage_info_returns_model(self, manager_immediate):
+        """get_disk_usage_info returns a DiskUsageInfo instance."""
+        with manager_immediate:
+            info = manager_immediate.get_disk_usage_info()
+            assert isinstance(info, DiskUsageInfo)
+
+    def test_get_disk_usage_info_has_correct_fields(self, manager_immediate):
+        """DiskUsageInfo has all required fields with correct types."""
+        with manager_immediate:
+            info = manager_immediate.get_disk_usage_info()
+            assert isinstance(info.total_gb, float)
+            assert isinstance(info.used_gb, float)
+            assert isinstance(info.free_gb, float)
+            assert isinstance(info.limit_gb, float)
+            assert isinstance(info.base_dir, Path)
+
+    def test_get_disk_usage_info_reports_configured_limit(self, tmp_path):
+        """DiskUsageInfo.limit_gb should reflect the configured max_disk_usage_gb."""
+        manager = TempFileManager(base_dir=tmp_path / "ws", max_disk_usage_gb=42.0, cleanup_policy="immediate")
+        with manager:
+            info = manager.get_disk_usage_info()
+            assert info.limit_gb == 42.0
+
+    def test_get_disk_usage_info_reports_base_dir(self, tmp_path):
+        """DiskUsageInfo.base_dir should reflect the manager's base_dir."""
+        base = tmp_path / "ws"
+        manager = TempFileManager(base_dir=base, max_disk_usage_gb=50.0, cleanup_policy="immediate")
+        with manager:
+            info = manager.get_disk_usage_info()
+            assert info.base_dir == base
+
+    def test_check_disk_space_does_not_raise(self, manager_immediate):
+        """check_disk_space should never raise exceptions, only return bool."""
+        with manager_immediate:
+            # Even with mocked failure, it should return False, not raise
+            mock_usage = _DiskUsage(total=100 * 1024**3, used=99 * 1024**3, free=0)
+            with patch("shutil.disk_usage", return_value=mock_usage):
+                result = manager_immediate.check_disk_space(required_gb=1.0)
+                assert result is False
+
+    def test_job_workspace_raises_oserror_when_disk_full(self, tmp_path):
+        """job_workspace raises OSError when disk space is insufficient (mocked)."""
+        manager = TempFileManager(base_dir=tmp_path / "ws", max_disk_usage_gb=50.0, cleanup_policy="immediate")
+
+        # Mock to simulate disk full
+        mock_usage = _DiskUsage(total=100 * 1024**3, used=99 * 1024**3, free=0)
+        with manager:
+            with patch("shutil.disk_usage", return_value=mock_usage):
+                with pytest.raises(OSError):
+                    with manager.job_workspace("job_full"):
+                        pass  # pragma: no cover
+
+    def test_check_disk_space_enforces_max_disk_usage_limit(self, tmp_path):
+        """check_disk_space returns False when consumed space exceeds max_disk_usage_gb."""
+        manager = TempFileManager(base_dir=tmp_path / "ws", max_disk_usage_gb=1.0, cleanup_policy="immediate")
+
+        with manager:
+            # At entry, _initial_free_gb was recorded from the real filesystem.
+            # Now mock disk_usage to simulate that 2 GB has been consumed since entry.
+            initial_free = manager._initial_free_gb
+            assert initial_free is not None
+
+            # Simulate: 2 GB consumed (more than the 1 GB limit)
+            mock_free = (initial_free - 2.0) * _BYTES_PER_GB
+            mock_usage = _DiskUsage(total=100 * _BYTES_PER_GB, used=50 * _BYTES_PER_GB, free=int(mock_free))
+            with patch("shutil.disk_usage", return_value=mock_usage):
+                result = manager.check_disk_space(required_gb=0.0001)
+                assert result is False
+
+
+# ===========================================================================
+# TestCleanup
+# ===========================================================================
+
+
+class TestCleanup:
+    """Tests for cleanup_all method."""
+
+    def test_removes_all_directories(self, manager_batch):
+        """cleanup_all removes all directories under base_dir."""
+        with manager_batch:
+            # Create several job workspaces (batch = persist after exit)
+            paths = []
+            for i in range(5):
+                with manager_batch.job_workspace(f"job_{i}") as ws:
+                    (ws / "output.dat").write_text(f"data_{i}", encoding="utf-8")
+                    paths.append(ws)
+
+            # All should exist
+            assert all(p.exists() for p in paths)
+
+            count = manager_batch.cleanup_all()
+            assert count == 5
+
+            # All should be gone
+            assert all(not p.exists() for p in paths)
+
+    def test_returns_correct_count(self, manager_batch):
+        """cleanup_all returns the number of directories removed."""
+        with manager_batch:
+            for i in range(3):
+                with manager_batch.job_workspace(f"job_{i}") as ws:
+                    pass
+
+            count = manager_batch.cleanup_all()
+            assert count == 3
+
+    def test_safe_when_no_directories_exist(self, manager_immediate):
+        """cleanup_all returns 0 when no directories exist."""
+        with manager_immediate:
+            count = manager_immediate.cleanup_all()
+            assert count == 0
+
+    def test_safe_to_call_multiple_times(self, manager_batch):
+        """cleanup_all can be called multiple times without error."""
+        with manager_batch:
+            with manager_batch.job_workspace("job_once") as ws:
+                pass
+
+            first_count = manager_batch.cleanup_all()
+            assert first_count == 1
+
+            second_count = manager_batch.cleanup_all()
+            assert second_count == 0
+
+            third_count = manager_batch.cleanup_all()
+            assert third_count == 0
+
+    def test_handles_permission_errors_gracefully(self, manager_batch):
+        """cleanup_all handles permission errors without raising."""
+        with manager_batch:
+            with manager_batch.job_workspace("job_perm") as ws:
+                (ws / "locked.dat").write_text("locked", encoding="utf-8")
+
+            # Mock shutil.rmtree to raise PermissionError
+            with patch("shutil.rmtree", side_effect=PermissionError("no permission")):
+                # Should NOT raise -- errors are logged but swallowed
+                count = manager_batch.cleanup_all()
+                # Count may be 0 since removal failed, but no exception
+                assert isinstance(count, int)
+
+    def test_cleanup_removes_nested_directories(self, manager_batch):
+        """cleanup_all removes workspaces containing nested subdirectories."""
+        with manager_batch:
+            with manager_batch.job_workspace("job_nested") as ws:
+                nested = ws / "subdir1" / "subdir2"
+                nested.mkdir(parents=True)
+                (nested / "deep_file.dat").write_text("deep", encoding="utf-8")
+                workspace_path = ws
+
+            assert workspace_path.exists()
+            count = manager_batch.cleanup_all()
+            assert count >= 1
+            assert not workspace_path.exists()
+
+
+# ===========================================================================
+# TestContextManager
+# ===========================================================================
+
+
+class TestContextManager:
+    """Tests for __enter__ / __exit__ protocol."""
+
+    def test_creates_base_dir_on_enter(self, tmp_path):
+        """__enter__ creates base_dir if it doesn't exist."""
+        base = tmp_path / "new_workspace_dir"
+        assert not base.exists()
+
+        manager = TempFileManager(base_dir=base, cleanup_policy="immediate")
+        with manager:
+            assert base.exists()
+
+    def test_cleans_up_on_exit_immediate(self, tmp_path):
+        """__exit__ cleans up for immediate policy."""
+        base = tmp_path / "ws_immediate"
+        manager = TempFileManager(base_dir=base, cleanup_policy="immediate")
+
+        with manager:
+            with manager.job_workspace("job_1") as ws:
+                (ws / "file.dat").write_text("data", encoding="utf-8")
+            # immediate cleanup already removed workspace
+            # but base_dir should be cleaned up on __exit__
+
+        # After __exit__, base_dir itself should be removed
+        assert not base.exists()
+
+    def test_cleans_up_on_exit_batch(self, tmp_path):
+        """__exit__ cleans up for batch policy."""
+        base = tmp_path / "ws_batch"
+        manager = TempFileManager(base_dir=base, cleanup_policy="batch")
+
+        with manager:
+            with manager.job_workspace("job_1") as ws:
+                workspace_path = ws
+            # batch policy -- workspace persists during context
+            assert workspace_path.exists()
+
+        # After __exit__, everything should be cleaned up
+        assert not base.exists()
+
+    def test_no_cleanup_on_exit_manual(self, tmp_path):
+        """__exit__ does NOT clean up for manual policy."""
+        base = tmp_path / "ws_manual"
+        manager = TempFileManager(base_dir=base, cleanup_policy="manual")
+
+        with manager:
+            with manager.job_workspace("job_1") as ws:
+                (ws / "file.dat").write_text("data", encoding="utf-8")
+                workspace_path = ws
+
+        # After __exit__ with manual policy, base_dir should still exist
+        assert base.exists()
+        assert workspace_path.exists()
+
+    def test_base_dir_removed_on_exit_non_manual(self, tmp_path):
+        """base_dir itself is removed on __exit__ for non-manual policies."""
+        for policy in ("immediate", "batch"):
+            base = tmp_path / f"ws_{policy}_remove"
+            manager = TempFileManager(base_dir=base, cleanup_policy=policy)
+            with manager:
+                assert base.exists()
+            assert not base.exists(), f"base_dir should be removed on __exit__ for {policy} policy"
+
+    def test_enter_returns_self(self, tmp_path):
+        """__enter__ returns the manager instance itself."""
+        manager = TempFileManager(base_dir=tmp_path / "ws", cleanup_policy="immediate")
+        with manager as m:
+            assert m is manager
+
+
+# ===========================================================================
+# TestEdgeCases
+# ===========================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_job_id_with_spaces(self, manager_immediate):
+        """job_id containing spaces should either work or raise ValueError."""
+        with manager_immediate:
+            try:
+                with manager_immediate.job_workspace("job with spaces") as ws:
+                    # If it works, the workspace should exist
+                    assert ws.exists()
+            except ValueError:
+                # Raising ValueError for invalid job_id is also acceptable
+                pass
+
+    def test_job_id_with_slashes_rejected(self, manager_immediate):
+        """job_id containing path separators is rejected with ValueError."""
+        with manager_immediate:
+            with pytest.raises(ValueError, match="path separators"):
+                with manager_immediate.job_workspace("job/sub/path"):
+                    pass  # pragma: no cover
+
+    def test_very_long_job_id(self, manager_immediate):
+        """Very long job_id should be handled (either works or raises)."""
+        long_id = "x" * 500
+        with manager_immediate:
+            try:
+                with manager_immediate.job_workspace(long_id) as ws:
+                    assert ws.exists()
+            except (ValueError, OSError):
+                # Raising for too-long IDs is acceptable
+                pass
+
+    def test_thread_safe_active_workspaces(self, tmp_path):
+        """active_workspaces tracking is thread-safe with concurrent access."""
+        manager = TempFileManager(base_dir=tmp_path / "ws", max_disk_usage_gb=50.0, cleanup_policy="batch")
+        errors = []
+
+        def worker(job_id):
+            try:
+                with manager.job_workspace(job_id) as ws:
+                    # Verify workspace is in active list
+                    assert ws in manager.active_workspaces
+            except Exception as e:
+                errors.append(e)
+
+        with manager:
+            threads = [threading.Thread(target=worker, args=(f"thread_job_{i}",)) for i in range(10)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert len(errors) == 0, f"Thread-safety errors: {errors}"
+
+    def test_base_dir_that_does_not_exist_created_on_enter(self, tmp_path):
+        """base_dir that doesn't exist is created when entering context."""
+        deep_path = tmp_path / "a" / "b" / "c" / "workspaces"
+        assert not deep_path.exists()
+
+        manager = TempFileManager(base_dir=deep_path, cleanup_policy="immediate")
+        with manager:
+            assert deep_path.exists()
+
+    def test_cleanup_workspace_with_nested_directories(self, manager_immediate):
+        """Cleanup handles workspaces with deeply nested subdirectories."""
+        with manager_immediate:
+            with manager_immediate.job_workspace("nested_job") as ws:
+                deep = ws / "a" / "b" / "c"
+                deep.mkdir(parents=True)
+                (deep / "result.dat").write_text("data", encoding="utf-8")
+                workspace_path = ws
+
+            # With immediate policy, nested directory should be fully cleaned
+            assert not workspace_path.exists()
+
+    def test_exception_inside_job_workspace_still_triggers_immediate_cleanup(self, manager_immediate):
+        """Exception propagation doesn't skip cleanup in immediate mode."""
+        with manager_immediate:
+            workspace_path = None
+            try:
+                with manager_immediate.job_workspace("error_job") as ws:
+                    workspace_path = ws
+                    (ws / "partial.dat").write_text("partial", encoding="utf-8")
+                    raise ValueError("processing failed")
+            except ValueError:
+                pass
+
+            assert workspace_path is not None
+            assert not workspace_path.exists()
+            assert workspace_path not in manager_immediate.active_workspaces
+
+    def test_multiple_files_in_workspace(self, manager_immediate):
+        """Workspace handles multiple files (simulating SAMMY's ~7 files per job)."""
+        with manager_immediate:
+            with manager_immediate.job_workspace("sammy_job") as ws:
+                # Simulate typical SAMMY job files
+                file_names = [
+                    "config.json",
+                    "input.dat",
+                    "output.dat",
+                    "par_file.par",
+                    "endf.dat",
+                    "results.lst",
+                    "chi_squared.txt",
+                ]
+                for name in file_names:
+                    (ws / name).write_text(f"content of {name}", encoding="utf-8")
+
+                # All files should exist
+                assert len(list(ws.iterdir())) == 7
+                workspace_path = ws
+
+            # After exit, everything should be cleaned up
+            assert not workspace_path.exists()
+
+
+# ===========================================================================
+# TestDiskUsageInfo
+# ===========================================================================
+
+
+class TestDiskUsageInfo:
+    """Tests for DiskUsageInfo pydantic model."""
+
+    def test_validates_fields_are_present(self):
+        """DiskUsageInfo requires all fields to be present."""
+        info = DiskUsageInfo(
+            total_gb=100.0,
+            used_gb=50.0,
+            free_gb=50.0,
+            limit_gb=80.0,
+            base_dir=Path("/tmp/test"),
+        )
+        assert info.total_gb == 100.0
+        assert info.used_gb == 50.0
+        assert info.free_gb == 50.0
+        assert info.limit_gb == 80.0
+        assert info.base_dir == Path("/tmp/test")
+
+    def test_float_fields_are_float(self):
+        """total_gb, used_gb, free_gb, limit_gb are all float."""
+        info = DiskUsageInfo(
+            total_gb=100.0,
+            used_gb=50.0,
+            free_gb=50.0,
+            limit_gb=80.0,
+            base_dir=Path("/tmp"),
+        )
+        assert isinstance(info.total_gb, float)
+        assert isinstance(info.used_gb, float)
+        assert isinstance(info.free_gb, float)
+        assert isinstance(info.limit_gb, float)
+
+    def test_base_dir_is_path(self):
+        """base_dir field is a Path instance."""
+        info = DiskUsageInfo(
+            total_gb=1.0,
+            used_gb=0.5,
+            free_gb=0.5,
+            limit_gb=1.0,
+            base_dir=Path("/tmp/workspace"),
+        )
+        assert isinstance(info.base_dir, Path)
+
+    def test_accepts_integer_coercion(self):
+        """Integer values should be coerced to float for numeric fields."""
+        info = DiskUsageInfo(
+            total_gb=100,
+            used_gb=50,
+            free_gb=50,
+            limit_gb=80,
+            base_dir=Path("/tmp"),
+        )
+        assert isinstance(info.total_gb, float)
+        assert info.total_gb == 100.0
+
+    def test_accepts_string_path(self):
+        """String path should be coerced to Path."""
+        info = DiskUsageInfo(
+            total_gb=1.0,
+            used_gb=0.5,
+            free_gb=0.5,
+            limit_gb=1.0,
+            base_dir="/tmp/test",
+        )
+        assert isinstance(info.base_dir, Path)
+        assert info.base_dir == Path("/tmp/test")
+
+
+# ===========================================================================
+# TestActiveWorkspaces
+# ===========================================================================
+
+
+class TestActiveWorkspaces:
+    """Tests for active_workspaces property."""
+
+    def test_initially_empty(self, manager_immediate):
+        """active_workspaces is empty before any workspace is created."""
+        with manager_immediate:
+            assert manager_immediate.active_workspaces == []
+
+    def test_returns_list(self, manager_immediate):
+        """active_workspaces returns a list."""
+        with manager_immediate:
+            assert isinstance(manager_immediate.active_workspaces, list)
+
+    def test_multiple_active_workspaces_tracked(self, manager_batch):
+        """Multiple active workspaces are all tracked simultaneously."""
+        with manager_batch:
+            workspaces = []
+            for i in range(3):
+                ctx = manager_batch.job_workspace(f"multi_{i}")
+                ws = ctx.__enter__()
+                workspaces.append((ctx, ws))
+
+            assert len(manager_batch.active_workspaces) == 3
+            for _, ws in workspaces:
+                assert ws in manager_batch.active_workspaces
+
+            # Clean up contexts
+            for ctx, _ in workspaces:
+                ctx.__exit__(None, None, None)
+
+    def test_returns_copy_not_internal_reference(self, manager_batch):
+        """active_workspaces should return a copy, not a direct reference to internal state."""
+        with manager_batch:
+            with manager_batch.job_workspace("ref_test") as ws:
+                active = manager_batch.active_workspaces
+                # Modifying the returned list should not affect internal state
+                active.clear()
+                assert ws in manager_batch.active_workspaces
+
+
+# ===========================================================================
+# TestOrchestratorIntegration
+# ===========================================================================
+
+
+class TestOrchestratorIntegration:
+    """Tests for BatchFittingOrchestrator + TempFileManager integration."""
+
+    def test_orchestrator_accepts_temp_manager(self, tmp_path):
+        """BatchFittingOrchestrator.__init__ accepts a temp_manager parameter."""
+        from pleiades.imaging.orchestrator import BatchFittingOrchestrator
+
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        mgr = TempFileManager(base_dir=tmp_path / "ws", cleanup_policy="batch")
+        config = _make_imaging_config()
+
+        orch = BatchFittingOrchestrator(imaging_config=config, sammy_executable=sammy_exe, temp_manager=mgr)
+        assert orch.temp_manager is mgr
+
+    def test_orchestrator_without_temp_manager_defaults_to_none(self, tmp_path):
+        """BatchFittingOrchestrator works without temp_manager (backward compat)."""
+        from pleiades.imaging.orchestrator import BatchFittingOrchestrator
+
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        config = _make_imaging_config()
+        orch = BatchFittingOrchestrator(imaging_config=config, sammy_executable=sammy_exe)
+        assert orch.temp_manager is None
+
+    def test_submit_pixels_extracts_base_dir_and_policy(self, tmp_path):
+        """_submit_pixels passes temp_base_dir and cleanup_policy from temp_manager."""
+        from concurrent.futures import ProcessPoolExecutor
+        from unittest.mock import MagicMock
+
+        from pleiades.imaging.orchestrator import BatchFittingOrchestrator
+
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        mgr = TempFileManager(base_dir=tmp_path / "ws", cleanup_policy="batch")
+        config = _make_imaging_config()
+
+        orch = BatchFittingOrchestrator(imaging_config=config, sammy_executable=sammy_exe, temp_manager=mgr)
+
+        mock_executor = MagicMock(spec=ProcessPoolExecutor)
+        mock_future = MagicMock()
+        mock_executor.submit.return_value = mock_future
+
+        pixel = _make_pixel(0, 0)
+        orch._submit_pixels(mock_executor, [pixel], Path("/json"), Path("/endf"))
+
+        # Verify submit was called with temp_base_dir and cleanup_policy
+        call_args = mock_executor.submit.call_args
+        assert call_args is not None
+        # positional args: (worker_fn, pixel, config, exe, resolution, json, endf, base_dir, policy)
+        args = call_args[0]
+        assert args[7] == tmp_path / "ws"  # temp_base_dir
+        assert args[8] == "batch"  # cleanup_policy
+
+    def test_submit_pixels_without_temp_manager_passes_none(self, tmp_path):
+        """Without temp_manager, _submit_pixels passes None for temp_base_dir."""
+        from concurrent.futures import ProcessPoolExecutor
+        from unittest.mock import MagicMock
+
+        from pleiades.imaging.orchestrator import BatchFittingOrchestrator
+
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        config = _make_imaging_config()
+        orch = BatchFittingOrchestrator(imaging_config=config, sammy_executable=sammy_exe)
+
+        mock_executor = MagicMock(spec=ProcessPoolExecutor)
+        mock_future = MagicMock()
+        mock_executor.submit.return_value = mock_future
+
+        pixel = _make_pixel(0, 0)
+        orch._submit_pixels(mock_executor, [pixel], Path("/json"), Path("/endf"))
+
+        call_args = mock_executor.submit.call_args
+        args = call_args[0]
+        assert args[7] is None  # temp_base_dir
+        assert args[8] == "immediate"  # cleanup_policy
+
+    def test_worker_creates_workspace_under_temp_base_dir(self, tmp_path):
+        """_fit_pixel_worker creates workspace under temp_base_dir when provided."""
+        from unittest.mock import MagicMock, patch
+
+        from pleiades.imaging.orchestrator import _fit_pixel_worker
+
+        pixel = _make_pixel(3, 7)
+        config = _make_imaging_config()
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+        base_dir = tmp_path / "managed_ws"
+        base_dir.mkdir()
+
+        # Mock the worker implementation to avoid SAMMY execution
+        mock_result = MagicMock()
+        mock_result.row = 3
+        mock_result.col = 7
+        mock_result.success = False
+        mock_result.error_message = "mock"
+
+        with patch("pleiades.imaging.orchestrator._fit_pixel_worker_impl") as mock_impl:
+            mock_impl.return_value = mock_result
+            _fit_pixel_worker(pixel, config, sammy_exe, temp_base_dir=base_dir, cleanup_policy="batch")
+
+            # Verify impl was called with a path under base_dir
+            call_args = mock_impl.call_args[0]
+            temp_path_arg = call_args[6]  # temp_path positional arg
+            assert temp_path_arg is not None
+            assert str(temp_path_arg).startswith(str(base_dir))
+            assert "pixel_3_7" in str(temp_path_arg)
+
+    def test_worker_falls_back_to_tempdir_without_temp_base_dir(self, tmp_path):
+        """_fit_pixel_worker uses tempfile.TemporaryDirectory when temp_base_dir is None."""
+        from unittest.mock import MagicMock, patch
+
+        from pleiades.imaging.orchestrator import _fit_pixel_worker
+
+        pixel = _make_pixel(1, 2)
+        config = _make_imaging_config()
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        mock_result = MagicMock()
+        mock_result.row = 1
+        mock_result.col = 2
+        mock_result.success = False
+        mock_result.error_message = "mock"
+
+        with patch("pleiades.imaging.orchestrator._fit_pixel_worker_impl") as mock_impl:
+            mock_impl.return_value = mock_result
+            _fit_pixel_worker(pixel, config, sammy_exe)  # No temp_base_dir
+
+            # Verify impl was called with temp_path=None (will use TemporaryDirectory)
+            call_args = mock_impl.call_args[0]
+            temp_path_arg = call_args[6]
+            assert temp_path_arg is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers for integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_imaging_config():
+    """Create a minimal ImagingConfig for testing."""
+    from pleiades.imaging.config import ImagingConfig
+
+    return ImagingConfig(
+        isotopes=["Ta-181"],
+        element="Ta",
+        mass_number=181,
+        density_g_cm3=16.6,
+        thickness_mm=0.025,
+        atomic_mass_amu=180.948,
+    )
+
+
+def _make_pixel(row: int, col: int):
+    """Create a minimal PixelSpectrum for testing."""
+    import numpy as np
+
+    from pleiades.imaging.models import PixelSpectrum
+
+    energy = np.linspace(1.0, 100.0, 10)
+    return PixelSpectrum(
+        row=row,
+        col=col,
+        energy=energy,
+        transmission=np.full(10, 0.9),
+        uncertainty=np.full(10, 0.01),
+    )


### PR DESCRIPTION
## Summary
- Implements `TempFileManager` class for centralized temp file management during batch SAMMY execution (262K+ pixel jobs)
- Three cleanup policies: `immediate` (per-job cleanup), `batch` (cleanup after all jobs), `manual` (user-managed)
- Disk usage enforcement via consumed-space tracking (`max_disk_usage_gb`)
- Thread-safe active workspace tracking with path traversal protection on `job_id`
- Integrated into `BatchFittingOrchestrator` with full backward compatibility

Closes #174

## Changes
- **New**: `src/pleiades/imaging/temp_manager.py` — `TempFileManager` and `DiskUsageInfo` classes
- **Modified**: `src/pleiades/imaging/orchestrator.py` — accepts optional `temp_manager`, passes `base_dir`/`cleanup_policy` to subprocess workers
- **New**: `tests/unit/pleiades/imaging/test_temp_manager.py` — 73 tests (67 unit + 6 integration)

## Test plan
- [x] 73 new tests pass (TempFileManager unit + orchestrator integration)
- [x] 220 total imaging tests pass, 0 regressions
- [x] Ruff check + format clean
- [x] All pre-commit hooks pass
- [x] Review agent: A- / APPROVED (Iteration 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)