### PR TITLE
feat(imaging): add AbundanceMapGenerator and AbundanceMapVisualizer (#179)

### DIFF
--- a/src/pleiades/imaging/__init__.py
+++ b/src/pleiades/imaging/__init__.py
@@ -20,10 +20,14 @@ Example:
 """
 
 from pleiades.imaging.aggregator import ResultsAggregator
+from pleiades.imaging.generator import AbundanceMapGenerator
 from pleiades.imaging.loader import HyperspectralLoader
 from pleiades.imaging.models import HyperspectralData, Imaging2DResults, PixelFitResult, PixelSpectrum
+from pleiades.imaging.visualizer import AbundanceMapVisualizer
 
 __all__ = [
+    "AbundanceMapGenerator",
+    "AbundanceMapVisualizer",
     "HyperspectralLoader",
     "HyperspectralData",
     "PixelSpectrum",

--- a/src/pleiades/imaging/generator.py
+++ b/src/pleiades/imaging/generator.py
@@ -1,0 +1,99 @@
+"""Abundance map generation from 2D imaging results.
+
+This module provides the AbundanceMapGenerator class which extracts individual
+isotope abundance maps and quality maps from an Imaging2DResults object.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pleiades.imaging.models import Imaging2DResults
+
+_VALID_QUALITY_METRICS = ("chi_squared", "success")
+
+
+class AbundanceMapGenerator:
+    """Extract isotope abundance and quality maps from imaging results.
+
+    Provides methods to retrieve individual isotope abundance maps, all maps
+    at once, and quality metric maps (chi-squared, success rate) from a
+    completed batch imaging run.
+
+    All returned arrays are copies to prevent accidental mutation of internal
+    data.
+
+    Args:
+        results: Completed 2D imaging results containing abundance maps,
+            isotope names, chi-squared map, and success mask.
+
+    Example:
+        >>> gen = AbundanceMapGenerator(imaging_results)
+        >>> ta_map = gen.generate_map("Ta-181")
+        >>> all_maps = gen.generate_all_maps()
+        >>> chi2 = gen.generate_quality_map("chi_squared")
+    """
+
+    def __init__(self, results: Imaging2DResults) -> None:
+        self._results = results
+        self._isotope_index = {name: i for i, name in enumerate(results.isotope_names)}
+
+    def generate_map(self, isotope: str, fill_value: float = np.nan) -> np.ndarray:
+        """Extract the 2D abundance map for a single isotope.
+
+        Args:
+            isotope: Isotope name (e.g. ``"Ta-181"``). Must be present in
+                the results.
+            fill_value: Value to substitute for NaN entries (failed pixels).
+                Defaults to ``np.nan`` (no replacement).
+
+        Returns:
+            2D array of shape ``(height, width)`` with abundance values.
+
+        Raises:
+            ValueError: If isotope is not found in the results.
+        """
+        if isotope not in self._isotope_index:
+            available = ", ".join(self._results.isotope_names) or "(none)"
+            raise ValueError(f"Unknown isotope {isotope!r}. Available: {available}")
+
+        idx = self._isotope_index[isotope]
+        result = self._results.abundance_maps[idx].copy()
+
+        if not np.isnan(fill_value):
+            nan_mask = np.isnan(result)
+            result[nan_mask] = fill_value
+
+        return result
+
+    def generate_all_maps(self) -> dict[str, np.ndarray]:
+        """Extract abundance maps for all isotopes.
+
+        Returns:
+            Dictionary mapping isotope name to 2D abundance array.
+            Each array is a copy of the internal data.
+        """
+        return {name: self.generate_map(name) for name in self._results.isotope_names}
+
+    def generate_quality_map(self, metric: str = "chi_squared") -> np.ndarray:
+        """Extract a 2D quality metric map.
+
+        Args:
+            metric: Quality metric to extract. Supported values:
+                - ``"chi_squared"``: Per-pixel chi-squared from fitting.
+                - ``"success"``: Success mask as float (1.0 = success, 0.0 = failure).
+
+        Returns:
+            2D array of shape ``(height, width)`` with quality values.
+
+        Raises:
+            ValueError: If metric is not one of the supported values.
+        """
+        if metric not in _VALID_QUALITY_METRICS:
+            raise ValueError(f"Unsupported metric {metric!r}. Valid metrics: {_VALID_QUALITY_METRICS}")
+
+        if metric == "chi_squared":
+            return self._results.chi_squared_map.copy()
+
+        # metric == "success"
+        return self._results.success_mask.astype(float, copy=True)

--- a/src/pleiades/imaging/visualizer.py
+++ b/src/pleiades/imaging/visualizer.py
@@ -1,0 +1,182 @@
+"""Visualization of isotope abundance maps from 2D imaging results.
+
+This module provides the AbundanceMapVisualizer class which produces
+matplotlib plots of isotope abundance maps, multi-isotope grids, and
+quality overlay visualizations.
+"""
+
+from __future__ import annotations
+
+import math
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+from pleiades.imaging.generator import AbundanceMapGenerator
+from pleiades.imaging.models import Imaging2DResults
+
+
+class AbundanceMapVisualizer:
+    """Visualize isotope abundance maps using matplotlib.
+
+    Creates publication-quality plots of individual isotope maps, multi-isotope
+    comparison grids, and quality metric overlays.
+
+    Callers are responsible for closing returned figures (``plt.close(fig)``)
+    to avoid memory leaks in batch processing loops.
+
+    Args:
+        results: Completed 2D imaging results.
+
+    Example:
+        >>> viz = AbundanceMapVisualizer(imaging_results)
+        >>> fig, ax = viz.plot_single_isotope("Ta-181")
+        >>> fig, axes = viz.plot_multi_isotope()
+        >>> fig, ax = viz.plot_quality_overlay("Ta-181")
+    """
+
+    def __init__(self, results: Imaging2DResults) -> None:
+        self._results = results
+        self._generator = AbundanceMapGenerator(results)
+
+    def plot_single_isotope(
+        self,
+        isotope: str,
+        ax: Axes | None = None,
+        cmap: str = "viridis",
+        vmin: float | None = None,
+        vmax: float | None = None,
+        show_colorbar: bool = True,
+    ) -> tuple[Figure, Axes]:
+        """Plot the abundance map for a single isotope.
+
+        Args:
+            isotope: Isotope name (e.g. ``"Ta-181"``).
+            ax: Matplotlib axes to plot on. If None, creates a new figure.
+                Note: when providing an axes from a complex layout,
+                ``fig.colorbar()`` may resize the axes.
+            cmap: Colormap name.
+            vmin: Minimum value for color scale. Auto-scaled if None.
+            vmax: Maximum value for color scale. Auto-scaled if None.
+            show_colorbar: Whether to add a colorbar.
+
+        Returns:
+            Tuple of (Figure, Axes).
+
+        Raises:
+            ValueError: If isotope is not found in the results.
+        """
+        abundance_map = self._generator.generate_map(isotope)
+
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.figure
+
+        im = ax.imshow(abundance_map, cmap=cmap, vmin=vmin, vmax=vmax, origin="upper")
+        ax.set_title(isotope)
+
+        if show_colorbar:
+            fig.colorbar(im, ax=ax)
+
+        return fig, ax
+
+    def plot_multi_isotope(
+        self,
+        isotopes: list[str] | None = None,
+        ncols: int = 3,
+        figsize: tuple[float, float] | None = None,
+    ) -> tuple[Figure, np.ndarray]:
+        """Plot abundance maps for multiple isotopes in a grid.
+
+        Args:
+            isotopes: List of isotope names to plot. If None, plots all.
+            ncols: Number of columns in the grid. Must be >= 1.
+            figsize: Figure size as (width, height). Auto-calculated if None.
+
+        Returns:
+            Tuple of (Figure, ndarray of Axes).
+
+        Raises:
+            ValueError: If any isotope in the list is not found, or if
+                isotopes list is empty, or if ncols < 1.
+        """
+        if ncols < 1:
+            raise ValueError(f"ncols must be >= 1, got {ncols}")
+
+        if isotopes is None:
+            isotopes = list(self._results.isotope_names)
+
+        if not isotopes:
+            raise ValueError("isotopes list must not be empty")
+
+        # Validate all isotopes exist before creating figures
+        for iso in isotopes:
+            if iso not in self._results.isotope_names:
+                available = ", ".join(self._results.isotope_names)
+                raise ValueError(f"Unknown isotope {iso!r}. Available: {available}")
+
+        n = len(isotopes)
+        nrows = max(1, math.ceil(n / ncols))
+
+        if figsize is None:
+            figsize = (4 * ncols, 4 * nrows)
+
+        fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
+
+        for i, iso in enumerate(isotopes):
+            row, col = divmod(i, ncols)
+            abundance_map = self._generator.generate_map(iso)
+            axes[row, col].imshow(abundance_map, cmap="viridis", origin="upper")
+            axes[row, col].set_title(iso)
+
+        # Hide unused axes
+        for i in range(n, nrows * ncols):
+            row, col = divmod(i, ncols)
+            axes[row, col].set_visible(False)
+
+        fig.tight_layout()
+        return fig, axes
+
+    def plot_quality_overlay(
+        self,
+        isotope: str,
+        quality_metric: str = "chi_squared",
+        alpha: float = 0.5,
+    ) -> tuple[Figure, Axes]:
+        """Plot an abundance map with a quality metric overlay.
+
+        Renders the abundance map as the base layer and overlays a
+        semi-transparent quality metric map on top.
+
+        Args:
+            isotope: Isotope name for the base abundance map.
+            quality_metric: Quality metric for the overlay (``"chi_squared"``
+                or ``"success"``).
+            alpha: Transparency of the overlay (0 = transparent, 1 = opaque).
+                Must be in [0, 1].
+
+        Returns:
+            Tuple of (Figure, Axes).
+
+        Raises:
+            ValueError: If isotope or quality_metric is invalid, or if
+                alpha is outside [0, 1].
+        """
+        if not 0.0 <= alpha <= 1.0:
+            raise ValueError(f"alpha must be in [0, 1], got {alpha}")
+
+        abundance_map = self._generator.generate_map(isotope)
+        quality_map = self._generator.generate_quality_map(metric=quality_metric)
+
+        fig, ax = plt.subplots()
+
+        ax.imshow(abundance_map, cmap="viridis", origin="upper")
+        im_overlay = ax.imshow(quality_map, cmap="hot", alpha=alpha, origin="upper")
+        ax.set_title(f"{isotope} + {quality_metric}")
+
+        fig.colorbar(im_overlay, ax=ax, label=quality_metric)
+
+        return fig, ax

--- a/tests/unit/pleiades/imaging/test_generator.py
+++ b/tests/unit/pleiades/imaging/test_generator.py
@@ -1,0 +1,525 @@
+"""Unit tests for AbundanceMapGenerator.
+
+These tests are written BEFORE implementation (TDD). They exercise the
+AbundanceMapGenerator class which extracts individual isotope abundance maps
+and quality maps from an Imaging2DResults object.
+
+Tests use real PLEIADES model classes and construct Imaging2DResults directly
+(not through the ResultsAggregator) for isolation and clarity.
+"""
+
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+import pytest
+
+from pleiades.imaging.generator import AbundanceMapGenerator
+from pleiades.imaging.models import HyperspectralData, Imaging2DResults
+
+# ---------------------------------------------------------------------------
+# Helper utilities for building test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_hyperspectral(height: int, width: int, n_energy: int = 10) -> HyperspectralData:
+    """Build a minimal HyperspectralData for testing.
+
+    Args:
+        height: Image height in pixels.
+        width: Image width in pixels.
+        n_energy: Number of energy channels.
+
+    Returns:
+        HyperspectralData with random transmission data.
+    """
+    rng = np.random.default_rng(42)
+    data = rng.uniform(0.3, 0.95, (n_energy, height, width)).astype(np.float32)
+    energy = np.linspace(1.0, 100.0, n_energy)
+    return HyperspectralData(
+        data=data,
+        energy=energy,
+        source_file=Path("/tmp/fake_source.tif"),
+    )
+
+
+def _make_imaging_results(
+    height: int = 4,
+    width: int = 4,
+    isotope_names: Optional[List[str]] = None,
+    abundance_values: Optional[np.ndarray] = None,
+    chi_squared_values: Optional[np.ndarray] = None,
+    success_mask: Optional[np.ndarray] = None,
+) -> Imaging2DResults:
+    """Build an Imaging2DResults directly from arrays.
+
+    This constructs the object without going through ResultsAggregator,
+    giving full control over array contents for precise test assertions.
+
+    Args:
+        height: Image height in pixels.
+        width: Image width in pixels.
+        isotope_names: List of isotope name strings. Defaults to ["Ta-181", "W-182"].
+        abundance_values: 3D array (n_isotopes, height, width). Generated randomly if None.
+        chi_squared_values: 2D array (height, width). Generated randomly if None.
+        success_mask: 2D bool array (height, width). Defaults to all True.
+
+    Returns:
+        Imaging2DResults instance.
+    """
+    if isotope_names is None:
+        isotope_names = ["Ta-181", "W-182"]
+    n_iso = len(isotope_names)
+
+    rng = np.random.default_rng(99)
+
+    if abundance_values is None:
+        abundance_values = rng.uniform(0.1, 0.9, (n_iso, height, width)).astype(np.float64)
+
+    if chi_squared_values is None:
+        chi_squared_values = rng.uniform(0.5, 5.0, (height, width)).astype(np.float64)
+
+    if success_mask is None:
+        success_mask = np.ones((height, width), dtype=bool)
+
+    source = _make_hyperspectral(height, width)
+
+    return Imaging2DResults(
+        abundance_maps=abundance_values,
+        isotope_names=isotope_names,
+        chi_squared_map=chi_squared_values,
+        success_mask=success_mask,
+        source_hyperspectral=source,
+        pixel_results=[],
+        metadata={},
+    )
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+@pytest.fixture
+def two_isotope_results() -> Imaging2DResults:
+    """Standard 4x4 image with two isotopes, all pixels successful."""
+    return _make_imaging_results(height=4, width=4, isotope_names=["Ta-181", "W-182"])
+
+
+@pytest.fixture
+def single_isotope_results() -> Imaging2DResults:
+    """Standard 4x4 image with a single isotope, all pixels successful."""
+    return _make_imaging_results(height=4, width=4, isotope_names=["Ta-181"])
+
+
+@pytest.fixture
+def results_with_failures() -> Imaging2DResults:
+    """4x4 image with two isotopes, some failed pixels (NaN in maps)."""
+    height, width = 4, 4
+    isotope_names = ["Ta-181", "W-182"]
+    n_iso = len(isotope_names)
+
+    rng = np.random.default_rng(77)
+    abundance = rng.uniform(0.1, 0.9, (n_iso, height, width)).astype(np.float64)
+    chi2 = rng.uniform(0.5, 5.0, (height, width)).astype(np.float64)
+    mask = np.ones((height, width), dtype=bool)
+
+    # Mark some pixels as failed
+    failed_positions = [(0, 1), (1, 3), (3, 0)]
+    for r, c in failed_positions:
+        abundance[:, r, c] = np.nan
+        chi2[r, c] = np.nan
+        mask[r, c] = False
+
+    return _make_imaging_results(
+        height=height,
+        width=width,
+        isotope_names=isotope_names,
+        abundance_values=abundance,
+        chi_squared_values=chi2,
+        success_mask=mask,
+    )
+
+
+@pytest.fixture
+def all_failed_results() -> Imaging2DResults:
+    """4x4 image where every pixel failed (all NaN)."""
+    height, width = 4, 4
+    isotope_names = ["Ta-181", "W-182"]
+    n_iso = len(isotope_names)
+
+    abundance = np.full((n_iso, height, width), np.nan, dtype=np.float64)
+    chi2 = np.full((height, width), np.nan, dtype=np.float64)
+    mask = np.zeros((height, width), dtype=bool)
+
+    return _make_imaging_results(
+        height=height,
+        width=width,
+        isotope_names=isotope_names,
+        abundance_values=abundance,
+        chi_squared_values=chi2,
+        success_mask=mask,
+    )
+
+
+@pytest.fixture
+def single_pixel_results() -> Imaging2DResults:
+    """1x1 image with one isotope, successful."""
+    abundance = np.array([[[0.75]]], dtype=np.float64)
+    chi2 = np.array([[1.5]], dtype=np.float64)
+    mask = np.array([[True]])
+
+    return _make_imaging_results(
+        height=1,
+        width=1,
+        isotope_names=["Ta-181"],
+        abundance_values=abundance,
+        chi_squared_values=chi2,
+        success_mask=mask,
+    )
+
+
+# ===========================================================================
+# TestAbundanceMapGenerator
+# ===========================================================================
+
+
+class TestAbundanceMapGeneratorInit:
+    """Tests for AbundanceMapGenerator.__init__."""
+
+    def test_init_stores_results(self, two_isotope_results: Imaging2DResults) -> None:
+        """Constructor should store the Imaging2DResults instance."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        # The generator should have access to the results data.
+        # We verify by checking it can later produce maps (tested elsewhere),
+        # but at minimum it should not raise on construction.
+        assert gen is not None
+
+    def test_init_with_single_isotope(self, single_isotope_results: Imaging2DResults) -> None:
+        """Constructor should accept results with a single isotope."""
+        gen = AbundanceMapGenerator(single_isotope_results)
+        assert gen is not None
+
+
+class TestGenerateMap:
+    """Tests for AbundanceMapGenerator.generate_map()."""
+
+    def test_returns_correct_shape(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_map should return a 2D array with shape (height, width)."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_map("Ta-181")
+        assert result.ndim == 2
+        expected_shape = two_isotope_results.abundance_maps.shape[1:]  # (height, width)
+        assert result.shape == expected_shape
+
+    def test_returns_correct_values_first_isotope(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_map for the first isotope should return the first layer of abundance_maps."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_map("Ta-181")
+        expected = two_isotope_results.abundance_maps[0]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_returns_correct_values_second_isotope(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_map for the second isotope should return the second layer of abundance_maps."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_map("W-182")
+        expected = two_isotope_results.abundance_maps[1]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_fill_value_replaces_nan(self, results_with_failures: Imaging2DResults) -> None:
+        """generate_map with fill_value should replace NaN in failed pixels."""
+        gen = AbundanceMapGenerator(results_with_failures)
+        result = gen.generate_map("Ta-181", fill_value=0.0)
+
+        # The result should contain no NaN values
+        assert not np.any(np.isnan(result))
+
+        # Failed pixel positions should now be 0.0
+        failed_mask = ~results_with_failures.success_mask
+        np.testing.assert_array_equal(result[failed_mask], 0.0)
+
+    def test_fill_value_does_not_affect_successful_pixels(self, results_with_failures: Imaging2DResults) -> None:
+        """fill_value should only replace NaN, not change successful pixel values."""
+        gen = AbundanceMapGenerator(results_with_failures)
+        result = gen.generate_map("Ta-181", fill_value=-999.0)
+
+        # Successful pixels should retain their original values
+        success_mask = results_with_failures.success_mask
+        original = results_with_failures.abundance_maps[0]
+        np.testing.assert_array_equal(result[success_mask], original[success_mask])
+
+    def test_fill_value_default_is_nan(self, results_with_failures: Imaging2DResults) -> None:
+        """Default fill_value should be NaN, preserving the original NaN values."""
+        gen = AbundanceMapGenerator(results_with_failures)
+        result = gen.generate_map("Ta-181")
+
+        # NaN positions should be preserved
+        original = results_with_failures.abundance_maps[0]
+        np.testing.assert_array_equal(np.isnan(result), np.isnan(original))
+
+    def test_fill_value_negative_one(self, results_with_failures: Imaging2DResults) -> None:
+        """fill_value=-1.0 should fill failed pixels with -1.0."""
+        gen = AbundanceMapGenerator(results_with_failures)
+        result = gen.generate_map("Ta-181", fill_value=-1.0)
+
+        failed_mask = ~results_with_failures.success_mask
+        np.testing.assert_array_equal(result[failed_mask], -1.0)
+
+    def test_unknown_isotope_raises_valueerror(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_map for an unknown isotope should raise ValueError."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        with pytest.raises(ValueError, match="(?i)isotope|not found|unknown"):
+            gen.generate_map("Hf-180")
+
+    def test_unknown_isotope_empty_string_raises(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_map with empty string isotope should raise ValueError."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        with pytest.raises(ValueError):
+            gen.generate_map("")
+
+    def test_single_isotope(self, single_isotope_results: Imaging2DResults) -> None:
+        """generate_map works correctly when there is only one isotope."""
+        gen = AbundanceMapGenerator(single_isotope_results)
+        result = gen.generate_map("Ta-181")
+        assert result.ndim == 2
+        expected = single_isotope_results.abundance_maps[0]
+        np.testing.assert_array_equal(result, expected)
+
+
+class TestGenerateMapEdgeCases:
+    """Edge case tests for generate_map."""
+
+    def test_single_pixel_image(self, single_pixel_results: Imaging2DResults) -> None:
+        """generate_map should work for a 1x1 image."""
+        gen = AbundanceMapGenerator(single_pixel_results)
+        result = gen.generate_map("Ta-181")
+        assert result.shape == (1, 1)
+        np.testing.assert_allclose(result[0, 0], 0.75)
+
+    def test_all_pixels_failed(self, all_failed_results: Imaging2DResults) -> None:
+        """generate_map with all-NaN map should return all NaN (default fill_value)."""
+        gen = AbundanceMapGenerator(all_failed_results)
+        result = gen.generate_map("Ta-181")
+        assert np.all(np.isnan(result))
+
+    def test_all_pixels_failed_with_fill_value(self, all_failed_results: Imaging2DResults) -> None:
+        """generate_map with all-NaN map and fill_value should fill every pixel."""
+        gen = AbundanceMapGenerator(all_failed_results)
+        result = gen.generate_map("Ta-181", fill_value=0.0)
+        np.testing.assert_array_equal(result, 0.0)
+        assert not np.any(np.isnan(result))
+
+    def test_all_pixels_succeeded(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_map with no NaN should return the same values regardless of fill_value."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result_default = gen.generate_map("Ta-181")
+        result_filled = gen.generate_map("Ta-181", fill_value=0.0)
+
+        # Both should be identical since there are no NaN values to replace
+        np.testing.assert_array_equal(result_default, result_filled)
+
+    def test_wide_image(self) -> None:
+        """generate_map works for a wide image (1 row, many columns)."""
+        results = _make_imaging_results(height=1, width=100, isotope_names=["Ta-181"])
+        gen = AbundanceMapGenerator(results)
+        result = gen.generate_map("Ta-181")
+        assert result.shape == (1, 100)
+
+    def test_tall_image(self) -> None:
+        """generate_map works for a tall image (many rows, 1 column)."""
+        results = _make_imaging_results(height=100, width=1, isotope_names=["Ta-181"])
+        gen = AbundanceMapGenerator(results)
+        result = gen.generate_map("Ta-181")
+        assert result.shape == (100, 1)
+
+
+class TestGenerateAllMaps:
+    """Tests for AbundanceMapGenerator.generate_all_maps()."""
+
+    def test_returns_dict(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_all_maps should return a dict."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_all_maps()
+        assert isinstance(result, dict)
+
+    def test_dict_keys_are_isotope_names(self, two_isotope_results: Imaging2DResults) -> None:
+        """Keys of the returned dict should be isotope names."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_all_maps()
+        assert set(result.keys()) == {"Ta-181", "W-182"}
+
+    def test_dict_values_are_2d_arrays(self, two_isotope_results: Imaging2DResults) -> None:
+        """Values of the returned dict should be 2D numpy arrays."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_all_maps()
+        for name, arr in result.items():
+            assert isinstance(arr, np.ndarray), f"Value for '{name}' is not ndarray"
+            assert arr.ndim == 2, f"Value for '{name}' is not 2D"
+
+    def test_values_match_individual_maps(self, two_isotope_results: Imaging2DResults) -> None:
+        """Each map in generate_all_maps should match the corresponding generate_map call."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        all_maps = gen.generate_all_maps()
+
+        for isotope_name in two_isotope_results.isotope_names:
+            expected = gen.generate_map(isotope_name)
+            np.testing.assert_array_equal(all_maps[isotope_name], expected)
+
+    def test_single_isotope(self, single_isotope_results: Imaging2DResults) -> None:
+        """generate_all_maps with one isotope returns dict with one entry."""
+        gen = AbundanceMapGenerator(single_isotope_results)
+        result = gen.generate_all_maps()
+        assert len(result) == 1
+        assert "Ta-181" in result
+
+    def test_three_isotopes(self) -> None:
+        """generate_all_maps with three isotopes returns dict with three entries."""
+        results = _make_imaging_results(height=3, width=3, isotope_names=["Ta-181", "W-182", "W-184"])
+        gen = AbundanceMapGenerator(results)
+        all_maps = gen.generate_all_maps()
+        assert len(all_maps) == 3
+        assert set(all_maps.keys()) == {"Ta-181", "W-182", "W-184"}
+
+    def test_with_failures_preserves_nan(self, results_with_failures: Imaging2DResults) -> None:
+        """generate_all_maps should preserve NaN values for failed pixels."""
+        gen = AbundanceMapGenerator(results_with_failures)
+        all_maps = gen.generate_all_maps()
+
+        for isotope_name in results_with_failures.isotope_names:
+            idx = results_with_failures.isotope_names.index(isotope_name)
+            original = results_with_failures.abundance_maps[idx]
+            np.testing.assert_array_equal(
+                np.isnan(all_maps[isotope_name]),
+                np.isnan(original),
+            )
+
+
+class TestGenerateQualityMap:
+    """Tests for AbundanceMapGenerator.generate_quality_map()."""
+
+    def test_chi_squared_returns_correct_map(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_quality_map('chi_squared') should return the chi_squared_map."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_quality_map(metric="chi_squared")
+        np.testing.assert_array_equal(result, two_isotope_results.chi_squared_map)
+
+    def test_chi_squared_is_default_metric(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_quality_map() with no argument should default to 'chi_squared'."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result_default = gen.generate_quality_map()
+        result_explicit = gen.generate_quality_map(metric="chi_squared")
+        np.testing.assert_array_equal(result_default, result_explicit)
+
+    def test_chi_squared_shape(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_quality_map('chi_squared') should return a 2D array."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_quality_map(metric="chi_squared")
+        assert result.ndim == 2
+        assert result.shape == two_isotope_results.chi_squared_map.shape
+
+    def test_chi_squared_preserves_nan(self, results_with_failures: Imaging2DResults) -> None:
+        """generate_quality_map('chi_squared') should preserve NaN for failed pixels."""
+        gen = AbundanceMapGenerator(results_with_failures)
+        result = gen.generate_quality_map(metric="chi_squared")
+        np.testing.assert_array_equal(
+            np.isnan(result),
+            np.isnan(results_with_failures.chi_squared_map),
+        )
+
+    def test_success_metric_returns_float_mask(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_quality_map('success') should return success_mask as float (1.0/0.0)."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_quality_map(metric="success")
+
+        # All pixels successful, so all should be 1.0
+        expected = np.ones((4, 4), dtype=float)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_success_metric_with_failures(self, results_with_failures: Imaging2DResults) -> None:
+        """generate_quality_map('success') should return 0.0 for failed pixels, 1.0 for successful."""
+        gen = AbundanceMapGenerator(results_with_failures)
+        result = gen.generate_quality_map(metric="success")
+
+        expected = results_with_failures.success_mask.astype(float)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_success_metric_dtype_is_float(self, results_with_failures: Imaging2DResults) -> None:
+        """generate_quality_map('success') should return float array, not bool."""
+        gen = AbundanceMapGenerator(results_with_failures)
+        result = gen.generate_quality_map(metric="success")
+        assert result.dtype in (np.float32, np.float64), f"Expected float dtype, got {result.dtype}"
+
+    def test_success_metric_shape(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_quality_map('success') should return a 2D array."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_quality_map(metric="success")
+        assert result.ndim == 2
+        assert result.shape == two_isotope_results.success_mask.shape
+
+    def test_invalid_metric_raises_valueerror(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_quality_map with unknown metric should raise ValueError."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        with pytest.raises(ValueError, match="(?i)metric|unsupported|unknown|invalid"):
+            gen.generate_quality_map(metric="r_squared")
+
+    def test_invalid_metric_empty_string(self, two_isotope_results: Imaging2DResults) -> None:
+        """generate_quality_map with empty string metric should raise ValueError."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        with pytest.raises(ValueError):
+            gen.generate_quality_map(metric="")
+
+    def test_all_failed_chi_squared(self, all_failed_results: Imaging2DResults) -> None:
+        """generate_quality_map('chi_squared') with all-failed should return all NaN."""
+        gen = AbundanceMapGenerator(all_failed_results)
+        result = gen.generate_quality_map(metric="chi_squared")
+        assert np.all(np.isnan(result))
+
+    def test_all_failed_success_metric(self, all_failed_results: Imaging2DResults) -> None:
+        """generate_quality_map('success') with all-failed should return all 0.0."""
+        gen = AbundanceMapGenerator(all_failed_results)
+        result = gen.generate_quality_map(metric="success")
+        np.testing.assert_array_equal(result, 0.0)
+
+    def test_single_pixel_chi_squared(self, single_pixel_results: Imaging2DResults) -> None:
+        """generate_quality_map works for a 1x1 image."""
+        gen = AbundanceMapGenerator(single_pixel_results)
+        result = gen.generate_quality_map(metric="chi_squared")
+        assert result.shape == (1, 1)
+        np.testing.assert_allclose(result[0, 0], 1.5)
+
+    def test_single_pixel_success_metric(self, single_pixel_results: Imaging2DResults) -> None:
+        """generate_quality_map('success') for 1x1 successful image returns 1.0."""
+        gen = AbundanceMapGenerator(single_pixel_results)
+        result = gen.generate_quality_map(metric="success")
+        assert result.shape == (1, 1)
+        np.testing.assert_allclose(result[0, 0], 1.0)
+
+
+class TestGenerateMapReturnsCopy:
+    """Tests to verify that generate_map returns a copy, not a view of the internal data."""
+
+    def test_modifying_result_does_not_affect_internal_data(self, two_isotope_results: Imaging2DResults) -> None:
+        """Modifying the returned map should not change the original results."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        result = gen.generate_map("Ta-181")
+        original_value = result[0, 0]
+
+        # Mutate the returned array
+        result[0, 0] = -999.0
+
+        # The generator should still return the original value
+        result2 = gen.generate_map("Ta-181")
+        np.testing.assert_allclose(result2[0, 0], original_value)
+
+    def test_modifying_all_maps_does_not_affect_internal_data(self, two_isotope_results: Imaging2DResults) -> None:
+        """Modifying a map from generate_all_maps should not change the original results."""
+        gen = AbundanceMapGenerator(two_isotope_results)
+        all_maps = gen.generate_all_maps()
+        original_value = all_maps["Ta-181"][0, 0]
+
+        # Mutate the returned array
+        all_maps["Ta-181"][0, 0] = -999.0
+
+        # The generator should still return the original value
+        all_maps2 = gen.generate_all_maps()
+        np.testing.assert_allclose(all_maps2["Ta-181"][0, 0], original_value)

--- a/tests/unit/pleiades/imaging/test_visualizer.py
+++ b/tests/unit/pleiades/imaging/test_visualizer.py
@@ -1,0 +1,506 @@
+"""Unit tests for AbundanceMapVisualizer.
+
+These tests are written BEFORE implementation (TDD). They exercise the
+AbundanceMapVisualizer class which produces matplotlib visualizations of
+isotope abundance maps and quality overlays from an Imaging2DResults object.
+
+Tests use the Agg backend to avoid requiring a display, and check figure
+structure (axes, colorbars, titles, shapes) rather than pixel-level rendering.
+"""
+
+from pathlib import Path
+from typing import List, Optional
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+# Force non-interactive backend before any other matplotlib imports
+matplotlib.use("Agg")
+
+from pleiades.imaging.models import HyperspectralData, Imaging2DResults  # noqa: E402
+from pleiades.imaging.visualizer import AbundanceMapVisualizer  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helper utilities for building test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_hyperspectral(height: int, width: int, n_energy: int = 10) -> HyperspectralData:
+    """Build a minimal HyperspectralData for testing.
+
+    Args:
+        height: Image height in pixels.
+        width: Image width in pixels.
+        n_energy: Number of energy channels.
+
+    Returns:
+        HyperspectralData with random transmission data.
+    """
+    rng = np.random.default_rng(42)
+    data = rng.uniform(0.3, 0.95, (n_energy, height, width)).astype(np.float32)
+    energy = np.linspace(1.0, 100.0, n_energy)
+    return HyperspectralData(
+        data=data,
+        energy=energy,
+        source_file=Path("/tmp/fake_source.tif"),
+    )
+
+
+def _make_imaging_results(
+    height: int = 4,
+    width: int = 4,
+    isotope_names: Optional[List[str]] = None,
+    abundance_values: Optional[np.ndarray] = None,
+    chi_squared_values: Optional[np.ndarray] = None,
+    success_mask: Optional[np.ndarray] = None,
+) -> Imaging2DResults:
+    """Build an Imaging2DResults directly from arrays.
+
+    Args:
+        height: Image height in pixels.
+        width: Image width in pixels.
+        isotope_names: List of isotope name strings. Defaults to ["Ta-181", "W-182"].
+        abundance_values: 3D array (n_isotopes, height, width). Generated randomly if None.
+        chi_squared_values: 2D array (height, width). Generated randomly if None.
+        success_mask: 2D bool array (height, width). Defaults to all True.
+
+    Returns:
+        Imaging2DResults instance.
+    """
+    if isotope_names is None:
+        isotope_names = ["Ta-181", "W-182"]
+    n_iso = len(isotope_names)
+
+    rng = np.random.default_rng(99)
+
+    if abundance_values is None:
+        abundance_values = rng.uniform(0.1, 0.9, (n_iso, height, width)).astype(np.float64)
+
+    if chi_squared_values is None:
+        chi_squared_values = rng.uniform(0.5, 5.0, (height, width)).astype(np.float64)
+
+    if success_mask is None:
+        success_mask = np.ones((height, width), dtype=bool)
+
+    source = _make_hyperspectral(height, width)
+
+    return Imaging2DResults(
+        abundance_maps=abundance_values,
+        isotope_names=isotope_names,
+        chi_squared_map=chi_squared_values,
+        success_mask=success_mask,
+        source_hyperspectral=source,
+        pixel_results=[],
+        metadata={},
+    )
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+@pytest.fixture(autouse=True)
+def close_figures_after_test():
+    """Close all matplotlib figures after each test to prevent resource leaks."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def two_isotope_results() -> Imaging2DResults:
+    """Standard 4x4 image with two isotopes, all pixels successful."""
+    return _make_imaging_results(height=4, width=4, isotope_names=["Ta-181", "W-182"])
+
+
+@pytest.fixture
+def single_isotope_results() -> Imaging2DResults:
+    """Standard 4x4 image with a single isotope, all pixels successful."""
+    return _make_imaging_results(height=4, width=4, isotope_names=["Ta-181"])
+
+
+@pytest.fixture
+def three_isotope_results() -> Imaging2DResults:
+    """Standard 4x4 image with three isotopes, all pixels successful."""
+    return _make_imaging_results(height=4, width=4, isotope_names=["Ta-181", "W-182", "W-184"])
+
+
+@pytest.fixture
+def results_with_failures() -> Imaging2DResults:
+    """4x4 image with two isotopes, some failed pixels (NaN in maps)."""
+    height, width = 4, 4
+    isotope_names = ["Ta-181", "W-182"]
+    n_iso = len(isotope_names)
+
+    rng = np.random.default_rng(77)
+    abundance = rng.uniform(0.1, 0.9, (n_iso, height, width)).astype(np.float64)
+    chi2 = rng.uniform(0.5, 5.0, (height, width)).astype(np.float64)
+    mask = np.ones((height, width), dtype=bool)
+
+    failed_positions = [(0, 1), (1, 3), (3, 0)]
+    for r, c in failed_positions:
+        abundance[:, r, c] = np.nan
+        chi2[r, c] = np.nan
+        mask[r, c] = False
+
+    return _make_imaging_results(
+        height=height,
+        width=width,
+        isotope_names=isotope_names,
+        abundance_values=abundance,
+        chi_squared_values=chi2,
+        success_mask=mask,
+    )
+
+
+@pytest.fixture
+def five_isotope_results() -> Imaging2DResults:
+    """Standard 4x4 image with five isotopes for testing multi-isotope grid layout."""
+    return _make_imaging_results(
+        height=4,
+        width=4,
+        isotope_names=["Ta-181", "W-182", "W-184", "Hf-180", "Re-185"],
+    )
+
+
+# ===========================================================================
+# TestAbundanceMapVisualizerInit
+# ===========================================================================
+
+
+class TestAbundanceMapVisualizerInit:
+    """Tests for AbundanceMapVisualizer.__init__."""
+
+    def test_init_stores_results(self, two_isotope_results: Imaging2DResults) -> None:
+        """Constructor should not raise and should store results."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        assert viz is not None
+
+    def test_init_with_single_isotope(self, single_isotope_results: Imaging2DResults) -> None:
+        """Constructor should accept results with a single isotope."""
+        viz = AbundanceMapVisualizer(single_isotope_results)
+        assert viz is not None
+
+
+# ===========================================================================
+# TestPlotSingleIsotope
+# ===========================================================================
+
+
+class TestPlotSingleIsotope:
+    """Tests for AbundanceMapVisualizer.plot_single_isotope()."""
+
+    def test_returns_figure_and_axes(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_single_isotope should return a tuple of (Figure, Axes)."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        result = viz.plot_single_isotope("Ta-181")
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        fig, ax = result
+        assert isinstance(fig, matplotlib.figure.Figure)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_creates_figure_with_colorbar(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_single_isotope should create a figure with a colorbar by default."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_single_isotope("Ta-181")
+
+        # A colorbar adds an extra axes to the figure
+        # The figure should have more than 1 axes when colorbar is present
+        assert len(fig.axes) > 1, "Expected colorbar axes in addition to the main axes"
+
+    def test_without_colorbar(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_single_isotope(show_colorbar=False) should not add a colorbar."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_single_isotope("Ta-181", show_colorbar=False)
+
+        # Without colorbar, figure should have exactly 1 axes
+        assert len(fig.axes) == 1, "Expected only one axes when colorbar is disabled"
+
+    def test_with_provided_axes(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_single_isotope should plot onto provided axes."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+
+        external_fig, external_ax = plt.subplots()
+        fig, ax = viz.plot_single_isotope("Ta-181", ax=external_ax)
+
+        # The returned axes should be the same as the one we provided
+        assert ax is external_ax
+
+    def test_with_custom_cmap(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_single_isotope should accept and use a custom colormap."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        # Should not raise with valid colormap
+        fig, ax = viz.plot_single_isotope("Ta-181", cmap="plasma")
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+    def test_with_custom_vmin_vmax(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_single_isotope should accept custom vmin and vmax."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_single_isotope("Ta-181", vmin=0.0, vmax=1.0)
+
+        # Verify the image has correct clim
+        images = ax.get_images()
+        assert len(images) > 0, "Expected at least one image in the axes"
+        clim = images[0].get_clim()
+        assert clim[0] == pytest.approx(0.0), f"Expected vmin=0.0, got {clim[0]}"
+        assert clim[1] == pytest.approx(1.0), f"Expected vmax=1.0, got {clim[1]}"
+
+    def test_with_only_vmin(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_single_isotope should accept only vmin (vmax auto-scaled)."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_single_isotope("Ta-181", vmin=0.0)
+
+        images = ax.get_images()
+        assert len(images) > 0
+        clim = images[0].get_clim()
+        assert clim[0] == pytest.approx(0.0)
+
+    def test_with_only_vmax(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_single_isotope should accept only vmax (vmin auto-scaled)."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_single_isotope("Ta-181", vmax=1.0)
+
+        images = ax.get_images()
+        assert len(images) > 0
+        clim = images[0].get_clim()
+        assert clim[1] == pytest.approx(1.0)
+
+    def test_unknown_isotope_raises_valueerror(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_single_isotope for an unknown isotope should raise ValueError."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        with pytest.raises(ValueError, match="(?i)isotope|not found|unknown"):
+            viz.plot_single_isotope("Hf-180")
+
+    def test_with_failures_does_not_raise(self, results_with_failures: Imaging2DResults) -> None:
+        """plot_single_isotope should handle NaN values without raising."""
+        viz = AbundanceMapVisualizer(results_with_failures)
+        fig, ax = viz.plot_single_isotope("Ta-181")
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+    def test_axes_has_image(self, two_isotope_results: Imaging2DResults) -> None:
+        """The returned axes should contain at least one image."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_single_isotope("Ta-181")
+        assert len(ax.get_images()) > 0, "Expected at least one image in the axes"
+
+
+# ===========================================================================
+# TestPlotMultiIsotope
+# ===========================================================================
+
+
+class TestPlotMultiIsotope:
+    """Tests for AbundanceMapVisualizer.plot_multi_isotope()."""
+
+    def test_returns_figure_and_axes_array(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_multi_isotope should return a tuple of (Figure, ndarray of Axes)."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        result = viz.plot_multi_isotope()
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        fig, axes = result
+        assert isinstance(fig, matplotlib.figure.Figure)
+        assert isinstance(axes, np.ndarray)
+
+    def test_plots_all_isotopes_by_default(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_multi_isotope() with no args should plot all isotopes."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, axes = viz.plot_multi_isotope()
+
+        # Should have at least 2 subplots (one per isotope)
+        # There may be extra empty subplots depending on grid layout
+        total_axes = axes.flatten()
+        # At minimum, the number of axes with images should match the isotope count
+        axes_with_images = [ax for ax in total_axes if len(ax.get_images()) > 0]
+        assert len(axes_with_images) >= 2, "Expected at least 2 subplots with images"
+
+    def test_with_subset_of_isotopes(self, three_isotope_results: Imaging2DResults) -> None:
+        """plot_multi_isotope(isotopes=[...]) should plot only the specified isotopes."""
+        viz = AbundanceMapVisualizer(three_isotope_results)
+        fig, axes = viz.plot_multi_isotope(isotopes=["Ta-181", "W-184"])
+
+        total_axes = axes.flatten()
+        axes_with_images = [ax for ax in total_axes if len(ax.get_images()) > 0]
+        assert len(axes_with_images) >= 2, "Expected at least 2 subplots with images"
+
+    def test_single_isotope_works(self, single_isotope_results: Imaging2DResults) -> None:
+        """plot_multi_isotope should work with a single isotope."""
+        viz = AbundanceMapVisualizer(single_isotope_results)
+        fig, axes = viz.plot_multi_isotope()
+
+        assert isinstance(fig, matplotlib.figure.Figure)
+        assert isinstance(axes, np.ndarray)
+
+        total_axes = axes.flatten()
+        axes_with_images = [ax for ax in total_axes if len(ax.get_images()) > 0]
+        assert len(axes_with_images) >= 1, "Expected at least 1 subplot with an image"
+
+    def test_with_custom_ncols(self, five_isotope_results: Imaging2DResults) -> None:
+        """plot_multi_isotope(ncols=2) should create a grid with 2 columns."""
+        viz = AbundanceMapVisualizer(five_isotope_results)
+        fig, axes = viz.plot_multi_isotope(ncols=2)
+
+        # With 5 isotopes and ncols=2, we need ceil(5/2) = 3 rows
+        # axes shape should be (3, 2) or equivalent
+        assert axes.size >= 5, "Expected at least 5 axes slots for 5 isotopes"
+
+    def test_with_custom_figsize(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_multi_isotope(figsize=(12, 8)) should create a figure with the specified size."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, axes = viz.plot_multi_isotope(figsize=(12, 8))
+
+        actual_size = fig.get_size_inches()
+        np.testing.assert_allclose(actual_size, (12, 8), atol=0.1)
+
+    def test_with_ncols_1(self, three_isotope_results: Imaging2DResults) -> None:
+        """plot_multi_isotope(ncols=1) should create a single-column grid."""
+        viz = AbundanceMapVisualizer(three_isotope_results)
+        fig, axes = viz.plot_multi_isotope(ncols=1)
+
+        # With 3 isotopes and ncols=1, we need 3 rows
+        total_axes = axes.flatten()
+        axes_with_images = [ax for ax in total_axes if len(ax.get_images()) > 0]
+        assert len(axes_with_images) >= 3
+
+    def test_unknown_isotope_in_list_raises(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_multi_isotope with unknown isotope in list should raise ValueError."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        with pytest.raises(ValueError, match="(?i)isotope|not found|unknown"):
+            viz.plot_multi_isotope(isotopes=["Ta-181", "Hf-180"])
+
+    def test_with_failures_does_not_raise(self, results_with_failures: Imaging2DResults) -> None:
+        """plot_multi_isotope should handle NaN values without raising."""
+        viz = AbundanceMapVisualizer(results_with_failures)
+        fig, axes = viz.plot_multi_isotope()
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+    def test_each_subplot_has_image(self, three_isotope_results: Imaging2DResults) -> None:
+        """Each isotope should get its own subplot with an image."""
+        viz = AbundanceMapVisualizer(three_isotope_results)
+        fig, axes = viz.plot_multi_isotope()
+
+        total_axes = axes.flatten()
+        axes_with_images = [ax for ax in total_axes if len(ax.get_images()) > 0]
+        assert len(axes_with_images) == 3, "Expected exactly 3 subplots with images for 3 isotopes"
+
+
+# ===========================================================================
+# TestPlotQualityOverlay
+# ===========================================================================
+
+
+class TestPlotQualityOverlay:
+    """Tests for AbundanceMapVisualizer.plot_quality_overlay()."""
+
+    def test_returns_figure_and_axes(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_quality_overlay should return a tuple of (Figure, Axes)."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        result = viz.plot_quality_overlay("Ta-181")
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        fig, ax = result
+        assert isinstance(fig, matplotlib.figure.Figure)
+        assert isinstance(ax, matplotlib.axes.Axes)
+
+    def test_default_quality_metric_chi_squared(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_quality_overlay should use chi_squared by default."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        # Should not raise -- the default metric should be valid
+        fig, ax = viz.plot_quality_overlay("Ta-181")
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+    def test_with_success_metric(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_quality_overlay with quality_metric='success' should not raise."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_quality_overlay("Ta-181", quality_metric="success")
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+    def test_with_custom_alpha(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_quality_overlay with custom alpha should not raise."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_quality_overlay("Ta-181", alpha=0.3)
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+    def test_has_images(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_quality_overlay should produce axes with at least two images (abundance + overlay)."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_quality_overlay("Ta-181")
+
+        # The overlay plot should have at least 2 images:
+        # one for the abundance map and one for the quality overlay
+        images = ax.get_images()
+        assert len(images) >= 2, f"Expected at least 2 images (base + overlay), got {len(images)}"
+
+    def test_unknown_isotope_raises(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_quality_overlay for an unknown isotope should raise ValueError."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        with pytest.raises(ValueError, match="(?i)isotope|not found|unknown"):
+            viz.plot_quality_overlay("Hf-180")
+
+    def test_invalid_quality_metric_raises(self, two_isotope_results: Imaging2DResults) -> None:
+        """plot_quality_overlay with invalid quality metric should raise ValueError."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        with pytest.raises(ValueError, match="(?i)metric|unsupported|unknown|invalid"):
+            viz.plot_quality_overlay("Ta-181", quality_metric="r_squared")
+
+    def test_with_failures_does_not_raise(self, results_with_failures: Imaging2DResults) -> None:
+        """plot_quality_overlay should handle NaN values without raising."""
+        viz = AbundanceMapVisualizer(results_with_failures)
+        fig, ax = viz.plot_quality_overlay("Ta-181")
+        assert isinstance(fig, matplotlib.figure.Figure)
+
+
+# ===========================================================================
+# TestResourceManagement
+# ===========================================================================
+
+
+class TestResourceManagement:
+    """Tests to verify that figures can be properly closed and cleaned up."""
+
+    def test_single_isotope_figure_can_be_closed(self, two_isotope_results: Imaging2DResults) -> None:
+        """Closing a figure from plot_single_isotope should not raise."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_single_isotope("Ta-181")
+        plt.close(fig)
+        # If we get here without error, the figure was properly closeable
+
+    def test_multi_isotope_figure_can_be_closed(self, two_isotope_results: Imaging2DResults) -> None:
+        """Closing a figure from plot_multi_isotope should not raise."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, axes = viz.plot_multi_isotope()
+        plt.close(fig)
+
+    def test_quality_overlay_figure_can_be_closed(self, two_isotope_results: Imaging2DResults) -> None:
+        """Closing a figure from plot_quality_overlay should not raise."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        fig, ax = viz.plot_quality_overlay("Ta-181")
+        plt.close(fig)
+
+    def test_close_all_figures(self, two_isotope_results: Imaging2DResults) -> None:
+        """plt.close('all') should work after creating multiple figures."""
+        viz = AbundanceMapVisualizer(two_isotope_results)
+        viz.plot_single_isotope("Ta-181")
+        viz.plot_single_isotope("W-182")
+        viz.plot_multi_isotope()
+        viz.plot_quality_overlay("Ta-181")
+
+        # Close all should not raise
+        plt.close("all")
+
+    def test_multiple_visualizers_do_not_conflict(self, two_isotope_results: Imaging2DResults) -> None:
+        """Two visualizer instances should not interfere with each other."""
+        viz1 = AbundanceMapVisualizer(two_isotope_results)
+        viz2 = AbundanceMapVisualizer(two_isotope_results)
+
+        fig1, ax1 = viz1.plot_single_isotope("Ta-181")
+        fig2, ax2 = viz2.plot_single_isotope("W-182")
+
+        # They should be different figure objects
+        assert fig1 is not fig2


### PR DESCRIPTION
## Summary
- Add `AbundanceMapGenerator` class for extracting individual isotope abundance maps and quality metric maps (chi-squared, success) from `Imaging2DResults`
- Add `AbundanceMapVisualizer` class with matplotlib plotting: single-isotope maps, multi-isotope grids, and quality overlay visualizations
- 77 new tests (41 generator, 36 visualizer) covering happy paths, edge cases, error handling, copy semantics, and resource management

## Test plan
- [x] All 318 imaging tests pass (77 new + 241 existing)
- [x] Ruff lint and format clean
- [x] Pre-commit hooks pass (including codespell)
- [x] Brutal review agent approved (iteration 2)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)