### PR TITLE
feat(imaging): SparsityAssessor for SNR-based severity classification (#183)

### DIFF
--- a/src/pleiades/imaging/__init__.py
+++ b/src/pleiades/imaging/__init__.py
@@ -21,6 +21,7 @@ Example:
 
 from pleiades.imaging.aggregator import ResultsAggregator
 from pleiades.imaging.api import analyze_imaging
+from pleiades.imaging.assessor import SparsityAssessor, SparsityMetrics
 from pleiades.imaging.degrader import DataDegrader
 from pleiades.imaging.generator import AbundanceMapGenerator
 from pleiades.imaging.loader import HyperspectralLoader
@@ -32,6 +33,8 @@ __all__ = [
     "AbundanceMapVisualizer",
     "DataDegrader",
     "HyperspectralLoader",
+    "SparsityAssessor",
+    "SparsityMetrics",
     "HyperspectralData",
     "PixelSpectrum",
     "PixelFitResult",

--- a/src/pleiades/imaging/assessor.py
+++ b/src/pleiades/imaging/assessor.py
@@ -124,7 +124,7 @@ class SparsityAssessor:
         # spatial_mean_spectrum: shape (n_energy,)
         spatial_mean = np.mean(data, axis=(1, 2), dtype=np.float64)
         min_transmission = float(np.min(spatial_mean))
-        resonance_depth = 1.0 - min_transmission
+        resonance_depth = max(0.0, 1.0 - min_transmission)
 
         mad = float(np.median(np.abs(spatial_mean - np.median(spatial_mean))))
         noise_estimate = mad / 0.6745  # normalise MAD → Gaussian std equivalent

--- a/src/pleiades/imaging/assessor.py
+++ b/src/pleiades/imaging/assessor.py
@@ -128,7 +128,9 @@ class SparsityAssessor:
 
         mad = float(np.median(np.abs(spatial_mean - np.median(spatial_mean))))
         noise_estimate = mad / 0.6745  # normalise MAD → Gaussian std equivalent
-        if noise_estimate == 0.0:
+        if resonance_depth == 0.0:
+            snr_estimate = 0.0
+        elif noise_estimate == 0.0:
             snr_estimate = float("inf")
         else:
             snr_estimate = resonance_depth / noise_estimate

--- a/src/pleiades/imaging/assessor.py
+++ b/src/pleiades/imaging/assessor.py
@@ -1,0 +1,185 @@
+"""Sparsity assessor for hyperspectral neutron imaging data.
+
+Provides ``SparsityAssessor`` which analyses a ``HyperspectralData`` cube and
+returns ``SparsityMetrics`` characterising the signal-to-noise regime and
+recommended processing strategy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+import numpy as np
+
+from pleiades.imaging.models import HyperspectralData
+
+
+@dataclass
+class SparsityMetrics:
+    """Quantitative sparsity characterisation of a hyperspectral dataset.
+
+    Attributes:
+        mean_transmission: Spatial and spectral mean of the transmission cube.
+        min_transmission: Global minimum transmission value.
+        resonance_depth: ``1 - min_transmission`` (depth of the deepest dip).
+        snr_estimate: ``resonance_depth / noise_estimate`` where noise is the
+            median absolute deviation across energy bins, normalised by 0.6745
+            to convert MAD to an equivalent Gaussian standard deviation.
+        zero_fraction: Fraction of transmission values below 0.01.
+        severity_level: Integer 0–4 encoding the sparsity regime.
+        severity_label: Human-readable label, e.g. ``"L0: Clean"``.
+        recommendations: List of processing recommendations such as
+            ``["direct_fitting"]`` or ``["bin_size=2", "increase_n_incident"]``.
+    """
+
+    mean_transmission: float
+    min_transmission: float
+    resonance_depth: float
+    snr_estimate: float
+    zero_fraction: float
+    severity_level: int
+    severity_label: str
+    recommendations: List[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Level definitions
+# ---------------------------------------------------------------------------
+
+_LEVEL_LABELS = {
+    0: "L0: Clean",
+    1: "L1: Mild noise",
+    2: "L2: Moderate sparse",
+    3: "L3: Heavy sparse",
+    4: "L4: Extreme sparse",
+}
+
+_LEVEL_RECOMMENDATIONS = {
+    0: ["direct_fitting"],
+    1: ["direct_fitting"],
+    2: ["bin_size=2"],
+    3: ["bin_size=4"],
+    4: ["bin_size=4", "physics_recovery"],
+}
+
+
+class SparsityAssessor:
+    """Assess the sparsity level of a hyperspectral neutron imaging dataset.
+
+    Estimates noise via the median absolute deviation (MAD) of the spatial
+    mean spectrum across energy bins, then classifies the dataset into one of
+    five severity levels (L0–L4) based on SNR and zero-fraction thresholds.
+
+    Usage::
+
+        assessor = SparsityAssessor()
+        metrics = assessor.assess(hyperspectral)
+        print(metrics.severity_label)   # e.g. "L2: Moderate sparse"
+        print(metrics.recommendations)  # e.g. ["bin_size=2"]
+    """
+
+    def assess(self, hyperspectral: HyperspectralData) -> SparsityMetrics:
+        """Assess sparsity of a hyperspectral dataset.
+
+        The noise estimate is the MAD of the spatial-mean spectrum over energy
+        bins, normalised to an equivalent Gaussian standard deviation
+        (``noise = MAD / 0.6745``).  The spatial mean averages over H×W pixels
+        for each energy bin so that pure spatial dead-pixel noise does not
+        inflate the estimate.
+
+        Severity classification rules (evaluated in order; first match wins):
+
+        ====== ===== ============== =====================================
+        Level  SNR   Zero fraction  Label
+        ====== ===== ============== =====================================
+        L0     >10   <1%            Clean
+        L1     5–10  <5%            Mild noise
+        L2     2–5   5–15%          Moderate sparse
+        L3     1–2   15–40%         Heavy sparse
+        L4     <1    >40%           Extreme sparse
+        ====== ===== ============== =====================================
+
+        When SNR and zero-fraction point to different levels, the *higher*
+        (more severe) level is chosen.
+
+        Args:
+            hyperspectral: Loaded hyperspectral dataset with shape
+                ``(n_energy, height, width)``.
+
+        Returns:
+            ``SparsityMetrics`` with all fields populated.
+        """
+        data = hyperspectral.data.astype(np.float64)
+
+        # --- Global scalar statistics ---
+        mean_transmission = float(np.mean(data))
+        min_transmission = float(np.min(data))
+        resonance_depth = 1.0 - min_transmission
+        zero_fraction = float(np.mean(data < 0.01))
+
+        # --- Noise estimate via MAD of the spatial-mean spectrum ---
+        # spatial_mean_spectrum: shape (n_energy,)
+        spatial_mean = data.mean(axis=(1, 2))
+        mad = float(np.median(np.abs(spatial_mean - np.median(spatial_mean))))
+        noise_estimate = mad / 0.6745  # normalise MAD → Gaussian std equivalent
+        if noise_estimate == 0.0:
+            snr_estimate = float("inf")
+        else:
+            snr_estimate = resonance_depth / noise_estimate
+
+        # --- Classify severity ---
+        severity_level = _classify_severity(snr_estimate, zero_fraction)
+        severity_label = _LEVEL_LABELS[severity_level]
+        recommendations = list(_LEVEL_RECOMMENDATIONS[severity_level])
+
+        return SparsityMetrics(
+            mean_transmission=mean_transmission,
+            min_transmission=min_transmission,
+            resonance_depth=resonance_depth,
+            snr_estimate=snr_estimate,
+            zero_fraction=zero_fraction,
+            severity_level=severity_level,
+            severity_label=severity_label,
+            recommendations=recommendations,
+        )
+
+
+def _classify_severity(snr: float, zero_fraction: float) -> int:
+    """Map (SNR, zero_fraction) to a severity level 0–4.
+
+    Both axes are evaluated independently and the *more severe* (higher) level
+    is returned.
+
+    Args:
+        snr: Signal-to-noise ratio (resonance_depth / noise_estimate).
+        zero_fraction: Fraction of transmission values below 0.01.
+
+    Returns:
+        Severity level integer 0–4.
+    """
+    # SNR axis
+    if snr > 10.0:
+        snr_level = 0
+    elif snr >= 5.0:
+        snr_level = 1
+    elif snr >= 2.0:
+        snr_level = 2
+    elif snr >= 1.0:
+        snr_level = 3
+    else:
+        snr_level = 4
+
+    # Zero-fraction axis
+    if zero_fraction < 0.01:
+        zf_level = 0
+    elif zero_fraction < 0.05:
+        zf_level = 1
+    elif zero_fraction < 0.15:
+        zf_level = 2
+    elif zero_fraction <= 0.40:
+        zf_level = 3
+    else:
+        zf_level = 4
+
+    return max(snr_level, zf_level)

--- a/src/pleiades/imaging/assessor.py
+++ b/src/pleiades/imaging/assessor.py
@@ -21,8 +21,9 @@ class SparsityMetrics:
 
     Attributes:
         mean_transmission: Spatial and spectral mean of the transmission cube.
-        min_transmission: Global minimum transmission value.
-        resonance_depth: ``1 - min_transmission`` (depth of the deepest dip).
+        min_transmission: Minimum of the spatial-mean transmission spectrum.
+        resonance_depth: ``1 - min_transmission`` (depth of the deepest dip
+            in the spatial-mean spectrum).
         snr_estimate: ``resonance_depth / noise_estimate`` where noise is the
             median absolute deviation across energy bins, normalised by 0.6745
             to convert MAD to an equivalent Gaussian standard deviation.
@@ -38,6 +39,9 @@ class SparsityMetrics:
     resonance_depth: float
     snr_estimate: float
     zero_fraction: float
+    # NOTE: min_transmission and resonance_depth are derived from the
+    # spatial-mean spectrum (not the global voxel minimum) so that the
+    # SNR estimate is self-consistent with the MAD noise estimate.
     severity_level: int
     severity_label: str
     recommendations: List[str] = field(default_factory=list)
@@ -110,17 +114,18 @@ class SparsityAssessor:
         Returns:
             ``SparsityMetrics`` with all fields populated.
         """
-        data = hyperspectral.data.astype(np.float64)
+        data = hyperspectral.data
 
         # --- Global scalar statistics ---
-        mean_transmission = float(np.mean(data))
-        min_transmission = float(np.min(data))
-        resonance_depth = 1.0 - min_transmission
+        mean_transmission = float(np.mean(data, dtype=np.float64))
         zero_fraction = float(np.mean(data < 0.01))
 
-        # --- Noise estimate via MAD of the spatial-mean spectrum ---
+        # --- Noise & signal from the spatial-mean spectrum ---
         # spatial_mean_spectrum: shape (n_energy,)
-        spatial_mean = data.mean(axis=(1, 2))
+        spatial_mean = np.mean(data, axis=(1, 2), dtype=np.float64)
+        min_transmission = float(np.min(spatial_mean))
+        resonance_depth = 1.0 - min_transmission
+
         mad = float(np.median(np.abs(spatial_mean - np.median(spatial_mean))))
         noise_estimate = mad / 0.6745  # normalise MAD → Gaussian std equivalent
         if noise_estimate == 0.0:

--- a/tests/unit/pleiades/imaging/test_assessor.py
+++ b/tests/unit/pleiades/imaging/test_assessor.py
@@ -308,6 +308,15 @@ class TestEdgeCases:
         assert m1.snr_estimate == m2.snr_estimate
         assert m1.zero_fraction == m2.zero_fraction
 
+    def test_overshoot_above_one_gives_zero_resonance_depth(self):
+        """Transmission > 1.0 (baseline overshoot) should not produce negative depth or SNR."""
+        assessor = SparsityAssessor()
+        data = np.full((50, 8, 8), 1.05)
+        hs = _make_hyperspectral(data)
+        m = assessor.assess(hs)
+        assert m.resonance_depth == 0.0
+        assert m.snr_estimate >= 0.0
+
     def test_high_zero_fraction_degrades_to_l4(self):
         assessor = SparsityAssessor()
         rng = np.random.default_rng(1)

--- a/tests/unit/pleiades/imaging/test_assessor.py
+++ b/tests/unit/pleiades/imaging/test_assessor.py
@@ -1,0 +1,318 @@
+"""Unit tests for pleiades.imaging.assessor.SparsityAssessor.
+
+Tests cover:
+  - SparsityMetrics field types and ranges
+  - All five severity levels (L0–L4) are reachable
+  - SNR and zero-fraction each independently trigger higher levels
+  - Noise estimation via MAD
+  - Recommendations map correctly to severity levels
+  - Edge cases: uniform data, all-zero data, zero resonance depth
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pleiades.imaging.assessor import SparsityAssessor, SparsityMetrics, _classify_severity
+from pleiades.imaging.models import HyperspectralData
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_hyperspectral(data: np.ndarray, energy: np.ndarray | None = None) -> HyperspectralData:
+    """Wrap a 3-D array in HyperspectralData with a synthetic source path."""
+    n_e = data.shape[0]
+    if energy is None:
+        energy = np.linspace(1.0, 100.0, n_e)
+    return HyperspectralData(
+        data=data,
+        energy=energy,
+        source_file=Path("/tmp/test.tif"),
+    )
+
+
+def _clean_data(n_e: int = 50, h: int = 8, w: int = 8, t_min: float = 0.5, t_bg: float = 0.9) -> np.ndarray:
+    """Create a synthetic clean dataset with a single sharp resonance dip."""
+    data = np.full((n_e, h, w), t_bg)
+    # Place a resonance at the centre energy bin — deep dip to t_min
+    data[n_e // 2, :, :] = t_min
+    return data
+
+
+# ---------------------------------------------------------------------------
+# TestSparsityMetricsFields
+# ---------------------------------------------------------------------------
+
+
+class TestSparsityMetricsFields:
+    def test_returns_sparsity_metrics_instance(self):
+        assessor = SparsityAssessor()
+        data = _clean_data()
+        hs = _make_hyperspectral(data)
+        metrics = assessor.assess(hs)
+        assert isinstance(metrics, SparsityMetrics)
+
+    def test_mean_transmission_in_range(self):
+        assessor = SparsityAssessor()
+        hs = _make_hyperspectral(_clean_data())
+        m = assessor.assess(hs)
+        assert 0.0 <= m.mean_transmission <= 1.0
+
+    def test_min_transmission_leq_mean(self):
+        assessor = SparsityAssessor()
+        hs = _make_hyperspectral(_clean_data())
+        m = assessor.assess(hs)
+        assert m.min_transmission <= m.mean_transmission
+
+    def test_resonance_depth_equals_one_minus_min(self):
+        assessor = SparsityAssessor()
+        hs = _make_hyperspectral(_clean_data(t_min=0.3))
+        m = assessor.assess(hs)
+        assert abs(m.resonance_depth - (1.0 - m.min_transmission)) < 1e-12
+
+    def test_snr_estimate_positive_for_resonance_data(self):
+        assessor = SparsityAssessor()
+        hs = _make_hyperspectral(_clean_data(t_min=0.3))
+        m = assessor.assess(hs)
+        assert m.snr_estimate > 0.0
+
+    def test_zero_fraction_zero_for_uniform_high_data(self):
+        assessor = SparsityAssessor()
+        data = np.full((30, 4, 4), 0.8)
+        hs = _make_hyperspectral(data)
+        m = assessor.assess(hs)
+        assert m.zero_fraction == 0.0
+
+    def test_zero_fraction_for_all_below_threshold(self):
+        assessor = SparsityAssessor()
+        # All values below 0.01
+        data = np.full((30, 4, 4), 0.005)
+        hs = _make_hyperspectral(data)
+        m = assessor.assess(hs)
+        assert m.zero_fraction == pytest.approx(1.0)
+
+    def test_severity_level_integer_in_range(self):
+        assessor = SparsityAssessor()
+        hs = _make_hyperspectral(_clean_data())
+        m = assessor.assess(hs)
+        assert m.severity_level in (0, 1, 2, 3, 4)
+
+    def test_severity_label_is_string(self):
+        assessor = SparsityAssessor()
+        hs = _make_hyperspectral(_clean_data())
+        m = assessor.assess(hs)
+        assert isinstance(m.severity_label, str)
+        assert len(m.severity_label) > 0
+
+    def test_recommendations_is_list_of_strings(self):
+        assessor = SparsityAssessor()
+        hs = _make_hyperspectral(_clean_data())
+        m = assessor.assess(hs)
+        assert isinstance(m.recommendations, list)
+        assert all(isinstance(r, str) for r in m.recommendations)
+        assert len(m.recommendations) >= 1
+
+
+# ---------------------------------------------------------------------------
+# TestSeverityLevels
+# ---------------------------------------------------------------------------
+
+
+class TestSeverityLevels:
+    """Verify each level 0–4 is reachable and produces correct labels/recs."""
+
+    def test_l0_clean_high_snr(self):
+        # Near-perfect data: background close to 1.0, deep clean resonance
+        # → very high SNR, near-zero zero_fraction → L0
+        assessor = SparsityAssessor()
+        data = _clean_data(n_e=200, h=16, w=16, t_min=0.01, t_bg=0.999)
+        hs = _make_hyperspectral(data)
+        m = assessor.assess(hs)
+        assert m.severity_level == 0
+        assert "L0" in m.severity_label
+        assert "direct_fitting" in m.recommendations
+
+    def test_l0_recommendations_direct_fitting(self):
+        assessor = SparsityAssessor()
+        m = SparsityMetrics(
+            mean_transmission=0.9,
+            min_transmission=0.5,
+            resonance_depth=0.5,
+            snr_estimate=50.0,
+            zero_fraction=0.001,
+            severity_level=0,
+            severity_label="L0: Clean",
+            recommendations=["direct_fitting"],
+        )
+        assert "direct_fitting" in m.recommendations
+
+    def test_l2_recommendations_bin_size_2(self):
+        assessor = SparsityAssessor()
+        # Force L2 via _classify_severity: snr in [2,5), zero_fraction in [5%,15%)
+        level = _classify_severity(snr=3.0, zero_fraction=0.08)
+        assert level == 2
+        from pleiades.imaging.assessor import _LEVEL_RECOMMENDATIONS
+
+        assert "bin_size=2" in _LEVEL_RECOMMENDATIONS[2]
+
+    def test_l3_recommendations_bin_size_4(self):
+        from pleiades.imaging.assessor import _LEVEL_RECOMMENDATIONS
+
+        assert "bin_size=4" in _LEVEL_RECOMMENDATIONS[3]
+
+    def test_l4_recommendations_physics_recovery(self):
+        from pleiades.imaging.assessor import _LEVEL_RECOMMENDATIONS
+
+        assert "physics_recovery" in _LEVEL_RECOMMENDATIONS[4]
+
+    def test_severity_label_matches_level(self):
+        from pleiades.imaging.assessor import _LEVEL_LABELS
+
+        for level, label in _LEVEL_LABELS.items():
+            assert f"L{level}" in label
+
+
+# ---------------------------------------------------------------------------
+# TestClassifySeverity
+# ---------------------------------------------------------------------------
+
+
+class TestClassifySeverity:
+    """Unit tests for the _classify_severity helper."""
+
+    def test_high_snr_low_zf_is_l0(self):
+        assert _classify_severity(snr=100.0, zero_fraction=0.001) == 0
+
+    def test_snr_7_low_zf_is_l1(self):
+        assert _classify_severity(snr=7.0, zero_fraction=0.001) == 1
+
+    def test_snr_3_low_zf_is_l2(self):
+        assert _classify_severity(snr=3.0, zero_fraction=0.001) == 2
+
+    def test_snr_1_5_low_zf_is_l3(self):
+        assert _classify_severity(snr=1.5, zero_fraction=0.001) == 3
+
+    def test_snr_below_1_is_l4(self):
+        assert _classify_severity(snr=0.5, zero_fraction=0.001) == 4
+
+    def test_zf_drives_level_up(self):
+        # SNR says L0 but zero_fraction says L3
+        level = _classify_severity(snr=100.0, zero_fraction=0.30)
+        assert level == 3
+
+    def test_takes_max_of_snr_and_zf_levels(self):
+        # SNR=L2, zf=L1 → L2
+        assert _classify_severity(snr=3.0, zero_fraction=0.02) == 2
+
+    def test_boundary_snr_10_is_l0(self):
+        # SNR > 10 → L0
+        assert _classify_severity(snr=10.01, zero_fraction=0.005) == 0
+
+    def test_boundary_snr_exactly_5_is_l1(self):
+        assert _classify_severity(snr=5.0, zero_fraction=0.005) == 1
+
+    def test_boundary_zf_0_01_is_l0(self):
+        # zero_fraction < 0.01 → L0 on zf axis
+        assert _classify_severity(snr=50.0, zero_fraction=0.009) == 0
+
+    def test_boundary_zf_exactly_0_05_is_l2(self):
+        # zero_fraction == 0.05 → L2 on zf axis (>= 0.05)
+        assert _classify_severity(snr=50.0, zero_fraction=0.05) == 2
+
+    def test_zero_snr_is_l4(self):
+        assert _classify_severity(snr=0.0, zero_fraction=0.0) == 4
+
+    def test_extreme_zf_is_l4(self):
+        assert _classify_severity(snr=50.0, zero_fraction=0.55) == 4
+
+
+# ---------------------------------------------------------------------------
+# TestNoiseEstimation
+# ---------------------------------------------------------------------------
+
+
+class TestNoiseEstimation:
+    def test_noiseless_uniform_gives_high_snr(self):
+        """Perfectly flat spectrum (no energy variation) → MAD=0 → SNR=inf."""
+        assessor = SparsityAssessor()
+        # Uniform across ALL energy bins → spatial mean is constant → MAD=0
+        data = np.full((50, 8, 8), 0.9)
+        hs = _make_hyperspectral(data)
+        m = assessor.assess(hs)
+        assert m.snr_estimate == float("inf")
+
+    def test_noisy_data_lower_snr_than_clean(self):
+        assessor = SparsityAssessor()
+        rng = np.random.default_rng(0)
+
+        clean = _clean_data(n_e=100, h=16, w=16, t_min=0.1, t_bg=0.95)
+        noisy = clean + rng.normal(0, 0.05, clean.shape)
+        noisy = np.clip(noisy, 0.0, 1.0)
+
+        m_clean = assessor.assess(_make_hyperspectral(clean))
+        m_noisy = assessor.assess(_make_hyperspectral(noisy))
+
+        assert m_noisy.snr_estimate < m_clean.snr_estimate
+
+    def test_snr_is_finite_for_noisy_data(self):
+        """Noisy (Poisson) data with spectral variation produces finite, positive SNR."""
+        assessor = SparsityAssessor()
+        rng = np.random.default_rng(42)
+        # Simulate Poisson noise: each pixel has independent noise per energy bin.
+        # This creates spectral variation in the spatial mean → non-zero MAD → finite SNR.
+        n_incident = 200.0
+        t_true = _clean_data(n_e=50, h=16, w=16, t_min=0.2, t_bg=0.9)
+        counts = rng.poisson(n_incident * t_true)
+        data = np.clip(counts / n_incident, 0.0, 1.0)
+        hs = _make_hyperspectral(data)
+        m = assessor.assess(hs)
+        # Should be finite and positive
+        assert np.isfinite(m.snr_estimate)
+        assert m.snr_estimate > 0.0
+
+
+# ---------------------------------------------------------------------------
+# TestEdgeCases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_single_pixel_image(self):
+        assessor = SparsityAssessor()
+        data = np.linspace(0.3, 0.95, 50).reshape(50, 1, 1)
+        hs = _make_hyperspectral(data)
+        m = assessor.assess(hs)
+        assert isinstance(m, SparsityMetrics)
+        assert 0 <= m.severity_level <= 4
+
+    def test_single_energy_bin(self):
+        assessor = SparsityAssessor()
+        data = np.full((1, 8, 8), 0.7)
+        energy = np.array([10.0])
+        hs = _make_hyperspectral(data, energy=energy)
+        m = assessor.assess(hs)
+        assert isinstance(m, SparsityMetrics)
+
+    def test_assess_is_deterministic(self):
+        """Running assess() twice on the same data yields identical metrics."""
+        assessor = SparsityAssessor()
+        hs = _make_hyperspectral(_clean_data())
+        m1 = assessor.assess(hs)
+        m2 = assessor.assess(hs)
+        assert m1.severity_level == m2.severity_level
+        assert m1.snr_estimate == m2.snr_estimate
+        assert m1.zero_fraction == m2.zero_fraction
+
+    def test_high_zero_fraction_degrades_to_l4(self):
+        assessor = SparsityAssessor()
+        rng = np.random.default_rng(1)
+        data = rng.uniform(0.0, 0.005, (50, 8, 8))  # nearly all below 0.01
+        hs = _make_hyperspectral(data)
+        m = assessor.assess(hs)
+        assert m.severity_level == 4
+        assert m.zero_fraction > 0.40

--- a/tests/unit/pleiades/imaging/test_assessor.py
+++ b/tests/unit/pleiades/imaging/test_assessor.py
@@ -309,13 +309,23 @@ class TestEdgeCases:
         assert m1.zero_fraction == m2.zero_fraction
 
     def test_overshoot_above_one_gives_zero_resonance_depth(self):
-        """Transmission > 1.0 (baseline overshoot) should not produce negative depth or SNR."""
+        """Transmission > 1.0 (baseline overshoot) should give zero depth and zero SNR."""
         assessor = SparsityAssessor()
         data = np.full((50, 8, 8), 1.05)
         hs = _make_hyperspectral(data)
         m = assessor.assess(hs)
         assert m.resonance_depth == 0.0
-        assert m.snr_estimate >= 0.0
+        assert m.snr_estimate == 0.0
+
+    def test_varying_overshoot_gives_zero_snr(self):
+        """Overshoot with spectral variation (nonzero MAD) should still give SNR=0."""
+        assessor = SparsityAssessor()
+        rng = np.random.default_rng(42)
+        data = 1.02 + rng.normal(0, 0.01, (50, 8, 8))
+        hs = _make_hyperspectral(data)
+        m = assessor.assess(hs)
+        assert m.resonance_depth == 0.0
+        assert m.snr_estimate == 0.0
 
     def test_high_zero_fraction_degrades_to_l4(self):
         assessor = SparsityAssessor()


### PR DESCRIPTION
## Summary

- Adds `SparsityAssessor` and `SparsityMetrics` in `src/pleiades/imaging/assessor.py`
- Noise estimated via MAD of the spatial-mean spectrum (normalised to Gaussian σ)
- L0–L4 severity levels based on SNR and zero-fraction thresholds
- Recommendations per level: `direct_fitting`, `bin_size=2`, `bin_size=4`, `physics_recovery`
- 36 unit tests covering all levels, boundary conditions, noise estimation, edge cases

## Test plan
- [x] `pixi run pytest tests/unit/pleiades/imaging/test_assessor.py -v` → 36 passed
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)