### PR TITLE
feat(imaging): SpatialBinner + bin_size in analyze_imaging (#186)

### DIFF
--- a/src/pleiades/imaging/__init__.py
+++ b/src/pleiades/imaging/__init__.py
@@ -22,6 +22,7 @@ Example:
 from pleiades.imaging.aggregator import ResultsAggregator
 from pleiades.imaging.api import analyze_imaging
 from pleiades.imaging.assessor import SparsityAssessor, SparsityMetrics
+from pleiades.imaging.binner import SpatialBinner
 from pleiades.imaging.degrader import DataDegrader
 from pleiades.imaging.generator import AbundanceMapGenerator
 from pleiades.imaging.loader import HyperspectralLoader
@@ -36,9 +37,10 @@ __all__ = [
     "SparsityAssessor",
     "SparsityMetrics",
     "HyperspectralData",
-    "PixelSpectrum",
-    "PixelFitResult",
     "Imaging2DResults",
+    "PixelFitResult",
+    "PixelSpectrum",
     "ResultsAggregator",
+    "SpatialBinner",
     "analyze_imaging",
 ]

--- a/src/pleiades/imaging/api.py
+++ b/src/pleiades/imaging/api.py
@@ -240,6 +240,22 @@ def analyze_imaging(
         if binner is not None:
             results = binner.unbin_results(results, original_hyperspectral)
 
+            # When ROI was expanded to align with bin boundaries, mask
+            # pixels outside the original ROI so fitted values don't
+            # leak beyond the requested region.
+            if roi is not None:
+                rx1, ry1, rx2, ry2 = roi
+                _, orig_h, orig_w = original_hyperspectral.shape
+                roi_mask = np.zeros((orig_h, orig_w), dtype=bool)
+                roi_mask[ry1:ry2, rx1:rx2] = True
+                outside = ~roi_mask
+
+                results.abundance_maps[:, outside] = np.nan
+                results.chi_squared_map[outside] = np.nan
+                results.success_mask[outside] = False
+                if results.fitted_energy_maps is not None:
+                    results.fitted_energy_maps[:, outside] = np.nan
+
         # --- 5. Optionally save ---
         if save_path is not None:
             logger.info(f"Saving results to {save_path}")

--- a/src/pleiades/imaging/api.py
+++ b/src/pleiades/imaging/api.py
@@ -14,12 +14,46 @@ from pleiades.imaging.aggregator import ResultsAggregator
 from pleiades.imaging.binner import SpatialBinner
 from pleiades.imaging.config import ImagingConfig
 from pleiades.imaging.loader import HyperspectralLoader
-from pleiades.imaging.models import Imaging2DResults
+from pleiades.imaging.models import HyperspectralData, Imaging2DResults, PixelSpectrum
 from pleiades.imaging.orchestrator import BatchFittingOrchestrator
 from pleiades.imaging.temp_manager import TempFileManager
 from pleiades.utils.logger import loguru_logger
 
 logger = loguru_logger.bind(name=__name__)
+
+
+def _iter_hyperspectral_pixels(
+    hyperspectral: HyperspectralData,
+    roi: tuple[int, int, int, int] | None = None,
+    stride: int = 1,
+):
+    """Yield PixelSpectrum objects directly from a HyperspectralData cube.
+
+    Used when the loader's ``iter_pixels`` would read from the wrong
+    (unbinned) cube — e.g. after spatial binning.
+    """
+    n_energy, height, width = hyperspectral.shape
+
+    if roi is None:
+        x1, y1, x2, y2 = 0, 0, width, height
+    else:
+        x1, y1, x2, y2 = roi
+
+    for row in range(y1, y2, stride):
+        for col in range(x1, x2, stride):
+            transmission = hyperspectral.data[:, row, col]
+            if hyperspectral.uncertainty is not None:
+                uncertainty = hyperspectral.uncertainty[:, row, col]
+            else:
+                uncertainty = 0.01 * np.abs(transmission)
+
+            yield PixelSpectrum(
+                row=row,
+                col=col,
+                energy=hyperspectral.energy,
+                transmission=transmission,
+                uncertainty=uncertainty,
+            )
 
 
 def analyze_imaging(
@@ -145,8 +179,21 @@ def analyze_imaging(
             resolution_file=resolution_file,
             temp_manager=temp_manager,
         )
+        # When binning is active, iterate over the binned hyperspectral
+        # instead of the loader's original unbinned cube, so that pixel
+        # coordinates match the binned (height, width) expected by the
+        # aggregator.
+        if binner is not None:
+
+            def pixel_factory():
+                return _iter_hyperspectral_pixels(hyperspectral, roi=roi, stride=stride)
+        else:
+
+            def pixel_factory():
+                return loader.iter_pixels(roi=roi, stride=stride)
+
         pixel_results = orchestrator.fit_pixels(
-            lambda: loader.iter_pixels(roi=roi, stride=stride),
+            pixel_factory,
             checkpoint_file=checkpoint_file,
             checkpoint_interval=checkpoint_interval,
             resume=resume,

--- a/src/pleiades/imaging/api.py
+++ b/src/pleiades/imaging/api.py
@@ -57,6 +57,7 @@ def _iter_hyperspectral_pixels(
                 energy=hyperspectral.energy,
                 transmission=transmission,
                 uncertainty=uncertainty,
+                metadata={"source": str(hyperspectral.source_file), "binned": True},
             )
 
 

--- a/src/pleiades/imaging/api.py
+++ b/src/pleiades/imaging/api.py
@@ -69,7 +69,6 @@ def analyze_imaging(
     n_workers: int = 4,
     roi: tuple[int, int, int, int] | None = None,
     stride: int = 1,
-    bin_size: int = 1,
     resolution_file: Path | None = None,
     checkpoint_file: Path | None = None,
     checkpoint_interval: int = 10,
@@ -78,6 +77,8 @@ def analyze_imaging(
     max_retries: int = 0,
     temp_manager: TempFileManager | None = None,
     save_path: Path | None = None,
+    *,
+    bin_size: int = 1,
 ) -> Imaging2DResults:
     """Perform 2D resonance imaging analysis.
 

--- a/src/pleiades/imaging/api.py
+++ b/src/pleiades/imaging/api.py
@@ -38,7 +38,9 @@ def _iter_hyperspectral_pixels(
         x1, y1, x2, y2 = 0, 0, width, height
     else:
         x1, y1, x2, y2 = roi
-        if not (0 <= x1 < x2 <= width and 0 <= y1 < y2 <= height):
+        # Allow x1 == x2 or y1 == y2 (empty ROI from edge-crop remapping)
+        # but reject reversed or out-of-bounds coordinates.
+        if not (0 <= x1 <= x2 <= width and 0 <= y1 <= y2 <= height):
             raise ValueError(f"Invalid ROI {roi} for image shape (height={height}, width={width})")
 
     for row in range(y1, y2, stride):

--- a/src/pleiades/imaging/api.py
+++ b/src/pleiades/imaging/api.py
@@ -154,6 +154,12 @@ def analyze_imaging(
     _, height, width = hyperspectral.shape
     logger.info(f"Loaded image: {height}x{width} pixels, {hyperspectral.shape[0]} energy bins")
 
+    # Validate ROI against original image dimensions (before binning)
+    if roi is not None:
+        x1, y1, x2, y2 = roi
+        if not (0 <= x1 < x2 <= width and 0 <= y1 < y2 <= height):
+            raise ValueError(f"Invalid ROI {roi} for image shape (height={height}, width={width})")
+
     # --- 1b. Optional spatial binning ---
     binner: SpatialBinner | None = None
     if bin_size > 1:
@@ -188,8 +194,10 @@ def analyze_imaging(
         if binner is not None:
             # Remap ROI from original coordinates to binned coordinates.
             # Start coords use floor division; end coords use ceiling
-            # division (to include any binned pixel overlapping the ROI),
-            # clamped to the binned dimensions.
+            # division to include any binned pixel overlapping the ROI.
+            # End coords are capped at binned dimensions because incomplete
+            # edge blocks were discarded during cropping.
+            # ROI was already validated against the original image above.
             if roi is not None:
                 bs = bin_size
                 binned_roi: tuple[int, int, int, int] | None = (

--- a/src/pleiades/imaging/api.py
+++ b/src/pleiades/imaging/api.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import numpy as np
 
 from pleiades.imaging.aggregator import ResultsAggregator
+from pleiades.imaging.binner import SpatialBinner
 from pleiades.imaging.config import ImagingConfig
 from pleiades.imaging.loader import HyperspectralLoader
 from pleiades.imaging.models import Imaging2DResults
@@ -30,6 +31,7 @@ def analyze_imaging(
     n_workers: int = 4,
     roi: tuple[int, int, int, int] | None = None,
     stride: int = 1,
+    bin_size: int = 1,
     resolution_file: Path | None = None,
     checkpoint_file: Path | None = None,
     checkpoint_interval: int = 10,
@@ -65,6 +67,10 @@ def analyze_imaging(
             fitted values, so for large strides most entries may be NaN; when
             visualizing or computing statistics, use NaN-aware methods or
             masking as appropriate.
+        bin_size: Spatial binning factor applied before fitting. ``bin_size=2``
+            averages 2×2 blocks of pixels before fitting and upscales results
+            back to the original resolution afterwards. Must be >= 1. Default
+            is 1 (no binning, fully backward-compatible).
         resolution_file: Optional path to instrument resolution function file.
             Forwarded to the SAMMY backend for broadening calculations.
         checkpoint_file: Path to save/load checkpoint data.
@@ -87,6 +93,8 @@ def analyze_imaging(
         raise ValueError(f"n_workers must be >= 1, got {n_workers}")
     if stride < 1:
         raise ValueError(f"stride must be >= 1, got {stride}")
+    if bin_size < 1:
+        raise ValueError(f"bin_size must be >= 1, got {bin_size}")
     if checkpoint_interval < 1:
         raise ValueError(f"checkpoint_interval must be >= 1, got {checkpoint_interval}")
     if max_retries < 0:
@@ -105,9 +113,18 @@ def analyze_imaging(
     else:
         loader = HyperspectralLoader(source, energy=energy)
     hyperspectral = loader.load()
+    original_hyperspectral = hyperspectral
 
     _, height, width = hyperspectral.shape
     logger.info(f"Loaded image: {height}x{width} pixels, {hyperspectral.shape[0]} energy bins")
+
+    # --- 1b. Optional spatial binning ---
+    binner: SpatialBinner | None = None
+    if bin_size > 1:
+        binner = SpatialBinner(bin_size=bin_size)
+        hyperspectral = binner.bin_hyperspectral(hyperspectral)
+        _, height, width = hyperspectral.shape
+        logger.info(f"Binned image (bin_size={bin_size}): {height}x{width} pixels")
 
     # --- Create default TempFileManager if none provided ---
     # Deferred until after loading succeeds so that early failures (missing
@@ -144,6 +161,10 @@ def analyze_imaging(
             width=width,
         )
         results = aggregator.aggregate(pixel_results, hyperspectral)
+
+        # --- 4b. Unbin results to original resolution ---
+        if binner is not None:
+            results = binner.unbin_results(results, original_hyperspectral)
 
         # --- 5. Optionally save ---
         if save_path is not None:

--- a/src/pleiades/imaging/api.py
+++ b/src/pleiades/imaging/api.py
@@ -38,6 +38,11 @@ def _iter_hyperspectral_pixels(
         x1, y1, x2, y2 = 0, 0, width, height
     else:
         x1, y1, x2, y2 = roi
+        # Clamp to actual dimensions as a safety net
+        x1 = max(0, min(x1, width))
+        y1 = max(0, min(y1, height))
+        x2 = max(0, min(x2, width))
+        y2 = max(0, min(y2, height))
 
     for row in range(y1, y2, stride):
         for col in range(x1, x2, stride):
@@ -184,9 +189,23 @@ def analyze_imaging(
         # coordinates match the binned (height, width) expected by the
         # aggregator.
         if binner is not None:
+            # Remap ROI from original coordinates to binned coordinates.
+            # Start coords use floor division; end coords use ceiling
+            # division (to include any binned pixel overlapping the ROI),
+            # clamped to the binned dimensions.
+            if roi is not None:
+                bs = bin_size
+                binned_roi: tuple[int, int, int, int] | None = (
+                    roi[0] // bs,
+                    roi[1] // bs,
+                    min(-(-roi[2] // bs), width),
+                    min(-(-roi[3] // bs), height),
+                )
+            else:
+                binned_roi = None
 
             def pixel_factory():
-                return _iter_hyperspectral_pixels(hyperspectral, roi=roi, stride=stride)
+                return _iter_hyperspectral_pixels(hyperspectral, roi=binned_roi, stride=stride)
         else:
 
             def pixel_factory():

--- a/src/pleiades/imaging/api.py
+++ b/src/pleiades/imaging/api.py
@@ -38,11 +38,8 @@ def _iter_hyperspectral_pixels(
         x1, y1, x2, y2 = 0, 0, width, height
     else:
         x1, y1, x2, y2 = roi
-        # Clamp to actual dimensions as a safety net
-        x1 = max(0, min(x1, width))
-        y1 = max(0, min(y1, height))
-        x2 = max(0, min(x2, width))
-        y2 = max(0, min(y2, height))
+        if not (0 <= x1 < x2 <= width and 0 <= y1 < y2 <= height):
+            raise ValueError(f"Invalid ROI {roi} for image shape (height={height}, width={width})")
 
     for row in range(y1, y2, stride):
         for col in range(x1, x2, stride):

--- a/src/pleiades/imaging/binner.py
+++ b/src/pleiades/imaging/binner.py
@@ -131,8 +131,10 @@ class SpatialBinner:
         if uh >= h and uw >= w:
             return upscaled[:h, :w]
 
-        # Pad with NaN if the upscaled result is smaller than original
-        result = np.full((h, w), np.nan, dtype=upscaled.dtype)
+        # Pad with NaN if the upscaled result is smaller than original.
+        # Promote to float if needed so NaN is representable.
+        pad_dtype = upscaled.dtype if np.issubdtype(upscaled.dtype, np.floating) else np.float64
+        result = np.full((h, w), np.nan, dtype=pad_dtype)
         result[: min(uh, h), : min(uw, w)] = upscaled[: min(uh, h), : min(uw, w)]
         return result
 

--- a/src/pleiades/imaging/binner.py
+++ b/src/pleiades/imaging/binner.py
@@ -120,11 +120,10 @@ class SpatialBinner:
             raise ValueError(f"binned_map must be 2-D, got {binned_map.ndim}D")
 
         if self.bin_size == 1:
-            h, w = original_shape
-            return binned_map[:h, :w]
-
-        # Nearest-neighbour upscale via np.repeat
-        upscaled = np.repeat(np.repeat(binned_map, self.bin_size, axis=0), self.bin_size, axis=1)
+            upscaled = binned_map
+        else:
+            # Nearest-neighbour upscale via np.repeat
+            upscaled = np.repeat(np.repeat(binned_map, self.bin_size, axis=0), self.bin_size, axis=1)
 
         # Crop/pad to original_shape
         h, w = original_shape

--- a/src/pleiades/imaging/binner.py
+++ b/src/pleiades/imaging/binner.py
@@ -65,19 +65,26 @@ class SpatialBinner:
             return hyperspectral
 
         data = hyperspectral.data  # (n_e, H, W)
-        n_e = data.shape[0]
+        n_e, h_orig, w_orig = data.shape
         bs = self.bin_size
+
+        # Crop to exact multiples of bin_size so no zero-padding occurs
+        h_crop = (h_orig // bs) * bs
+        w_crop = (w_orig // bs) * bs
+        data = data[:, :h_crop, :w_crop]
 
         func = np.mean if self.method == "mean" else np.median
         # block_reduce over spatial axes (1, 2); axis 0 (energy) block = 1
         block_shape = (1, bs, bs)
         binned_data = block_reduce(data, block_size=block_shape, func=func)
 
-        # Uncertainty propagation
+        # Uncertainty propagation: σ_bin = sqrt(Σ σ_i²) / N for N = bs²
         binned_uncertainty = None
         if hyperspectral.uncertainty is not None:
-            binned_uncertainty = block_reduce(hyperspectral.uncertainty, block_size=block_shape, func=np.mean)
-            binned_uncertainty = binned_uncertainty / bs  # σ_bin = σ_pixel / sqrt(N²) = σ_pixel / N
+            unc_cropped = hyperspectral.uncertainty[:, :h_crop, :w_crop]
+            variance_sum = block_reduce(unc_cropped**2, block_size=block_shape, func=np.sum)
+            n_pixels = bs * bs
+            binned_uncertainty = np.sqrt(variance_sum) / n_pixels
 
         return HyperspectralData(
             data=binned_data,

--- a/src/pleiades/imaging/binner.py
+++ b/src/pleiades/imaging/binner.py
@@ -19,7 +19,7 @@ class SpatialBinner:
     """Bin and unbin hyperspectral imaging data spatially.
 
     Averaging an N×N block of pixels improves SNR by a factor of N (noise
-    decreases as 1/sqrt(N²) relative to a single pixel).  The binned data
+    is reduced to 1/N of that of a single pixel).  The binned data
     can be processed by the normal fitting pipeline and then unbinned back
     to the original resolution.
 
@@ -50,8 +50,8 @@ class SpatialBinner:
         complete block are discarded (floor division).
 
         Uncertainty propagation:
-            ``σ_bin = σ_pixel / sqrt(bin_size²)`` — the per-bin uncertainty
-            decreases by ``1/bin_size`` assuming uncorrelated Gaussian noise.
+            ``σ_bin = sqrt(Σ σ_i²) / N`` where N = bin_size² — correct for
+            independent pixels with heterogeneous uncertainties.
 
         Args:
             hyperspectral: Dataset of shape ``(n_energy, H, W)``.

--- a/src/pleiades/imaging/binner.py
+++ b/src/pleiades/imaging/binner.py
@@ -1,0 +1,184 @@
+"""Spatial binning for hyperspectral imaging data.
+
+Provides ``SpatialBinner`` to reduce spatial resolution by averaging N×N blocks
+of pixels, improving SNR for sparse / noisy datasets. Includes unbinning helpers
+to restore results to the original spatial shape.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+from skimage.measure import block_reduce
+
+from pleiades.imaging.models import HyperspectralData, Imaging2DResults
+
+
+class SpatialBinner:
+    """Bin and unbin hyperspectral imaging data spatially.
+
+    Averaging an N×N block of pixels improves SNR by a factor of N (noise
+    decreases as 1/sqrt(N²) relative to a single pixel).  The binned data
+    can be processed by the normal fitting pipeline and then unbinned back
+    to the original resolution.
+
+    Args:
+        bin_size: Spatial binning factor.  ``bin_size=2`` averages 2×2 blocks
+            (4 pixels → 1), ``bin_size=4`` averages 4×4 blocks.  Must be >= 1.
+            ``bin_size=1`` is a no-op identity.
+        method: Aggregation method for each block.  ``"mean"`` (default) or
+            ``"median"``.
+
+    Raises:
+        ValueError: If ``bin_size < 1`` or ``method`` is not recognised.
+    """
+
+    def __init__(self, bin_size: int, method: str = "mean") -> None:
+        if bin_size < 1:
+            raise ValueError(f"bin_size must be >= 1, got {bin_size}")
+        if method not in ("mean", "median"):
+            raise ValueError(f"method must be 'mean' or 'median', got {method!r}")
+        self.bin_size = bin_size
+        self.method = method
+
+    def bin_hyperspectral(self, hyperspectral: HyperspectralData) -> HyperspectralData:
+        """Bin the spatial dimensions of a hyperspectral dataset.
+
+        The energy axis is left unchanged.  Spatial dimensions are reduced by
+        ``bin_size`` via block averaging.  Rows/columns that do not fill a
+        complete block are discarded (floor division).
+
+        Uncertainty propagation:
+            ``σ_bin = σ_pixel / sqrt(bin_size²)`` — the per-bin uncertainty
+            decreases by ``1/bin_size`` assuming uncorrelated Gaussian noise.
+
+        Args:
+            hyperspectral: Dataset of shape ``(n_energy, H, W)``.
+
+        Returns:
+            New ``HyperspectralData`` of shape
+            ``(n_energy, H // bin_size, W // bin_size)`` with the same energy
+            axis and updated uncertainty (if present).
+        """
+        if self.bin_size == 1:
+            return hyperspectral
+
+        data = hyperspectral.data  # (n_e, H, W)
+        n_e = data.shape[0]
+        bs = self.bin_size
+
+        func = np.mean if self.method == "mean" else np.median
+        # block_reduce over spatial axes (1, 2); axis 0 (energy) block = 1
+        block_shape = (1, bs, bs)
+        binned_data = block_reduce(data, block_size=block_shape, func=func)
+
+        # Uncertainty propagation
+        binned_uncertainty = None
+        if hyperspectral.uncertainty is not None:
+            binned_uncertainty = block_reduce(hyperspectral.uncertainty, block_size=block_shape, func=np.mean)
+            binned_uncertainty = binned_uncertainty / bs  # σ_bin = σ_pixel / sqrt(N²) = σ_pixel / N
+
+        return HyperspectralData(
+            data=binned_data,
+            energy=hyperspectral.energy.copy(),
+            uncertainty=binned_uncertainty,
+            source_file=hyperspectral.source_file,
+            metadata={**hyperspectral.metadata, "bin_size": bs},
+        )
+
+    def unbin_map(self, binned_map: np.ndarray, original_shape: Tuple[int, int]) -> np.ndarray:
+        """Upscale a 2-D binned map to the original spatial resolution.
+
+        Uses nearest-neighbour repeat: each binned value is copied into a
+        ``bin_size × bin_size`` tile.  NaN values are preserved.
+
+        Args:
+            binned_map: 2-D array of shape ``(H_bin, W_bin)``.
+            original_shape: Target ``(H, W)`` shape to upscale to.
+
+        Returns:
+            2-D array of shape ``original_shape``.  The output is cropped or
+            padded (with NaN) to match ``original_shape`` exactly.
+
+        Raises:
+            ValueError: If ``binned_map`` is not 2-D.
+        """
+        if binned_map.ndim != 2:
+            raise ValueError(f"binned_map must be 2-D, got {binned_map.ndim}D")
+
+        if self.bin_size == 1:
+            h, w = original_shape
+            return binned_map[:h, :w]
+
+        # Nearest-neighbour upscale via np.repeat
+        upscaled = np.repeat(np.repeat(binned_map, self.bin_size, axis=0), self.bin_size, axis=1)
+
+        # Crop/pad to original_shape
+        h, w = original_shape
+        uh, uw = upscaled.shape
+        if uh >= h and uw >= w:
+            return upscaled[:h, :w]
+
+        # Pad with NaN if the upscaled result is smaller than original
+        result = np.full((h, w), np.nan, dtype=upscaled.dtype)
+        result[: min(uh, h), : min(uw, w)] = upscaled[: min(uh, h), : min(uw, w)]
+        return result
+
+    def unbin_results(self, results: Imaging2DResults, original_hyperspectral: HyperspectralData) -> Imaging2DResults:
+        """Upscale all spatial maps in ``results`` to the original image resolution.
+
+        Upscales:
+        - ``abundance_maps`` (3-D: each isotope map individually)
+        - ``chi_squared_map`` (2-D)
+        - ``success_mask`` (2-D boolean)
+        - ``fitted_energy_maps`` (3-D, if present)
+
+        Restores ``source_hyperspectral`` to ``original_hyperspectral`` and
+        records ``bin_size`` in ``results.metadata``.
+
+        Args:
+            results: ``Imaging2DResults`` from the binned pipeline run.
+            original_hyperspectral: The pre-binning ``HyperspectralData``.
+
+        Returns:
+            New ``Imaging2DResults`` with all spatial maps at original resolution.
+        """
+        _, orig_h, orig_w = original_hyperspectral.shape
+        original_shape = (orig_h, orig_w)
+
+        # Abundance maps: (n_isotopes, H_bin, W_bin) → (n_isotopes, H, W)
+        n_isotopes = results.abundance_maps.shape[0]
+        unbinned_abundance = np.stack(
+            [self.unbin_map(results.abundance_maps[i], original_shape) for i in range(n_isotopes)],
+            axis=0,
+        )
+
+        # Chi-squared map
+        unbinned_chi2 = self.unbin_map(results.chi_squared_map, original_shape)
+
+        # Success mask (boolean)
+        unbinned_success_float = self.unbin_map(results.success_mask.astype(np.float64), original_shape)
+        unbinned_success = unbinned_success_float.astype(bool)
+
+        # Fitted energy maps (optional)
+        unbinned_energy_maps = None
+        if results.fitted_energy_maps is not None:
+            n_res = results.fitted_energy_maps.shape[0]
+            unbinned_energy_maps = np.stack(
+                [self.unbin_map(results.fitted_energy_maps[r], original_shape) for r in range(n_res)],
+                axis=0,
+            )
+
+        updated_metadata = {**results.metadata, "bin_size": self.bin_size}
+
+        return Imaging2DResults(
+            abundance_maps=unbinned_abundance,
+            isotope_names=results.isotope_names,
+            fitted_energy_maps=unbinned_energy_maps,
+            chi_squared_map=unbinned_chi2,
+            success_mask=unbinned_success,
+            source_hyperspectral=original_hyperspectral,
+            pixel_results=results.pixel_results,
+            metadata=updated_metadata,
+        )

--- a/src/pleiades/imaging/binner.py
+++ b/src/pleiades/imaging/binner.py
@@ -71,6 +71,11 @@ class SpatialBinner:
         # Crop to exact multiples of bin_size so no zero-padding occurs
         h_crop = (h_orig // bs) * bs
         w_crop = (w_orig // bs) * bs
+        if h_crop == 0 or w_crop == 0:
+            raise ValueError(
+                f"bin_size={bs} produces a zero-sized binned image for input shape "
+                f"({h_orig}, {w_orig}); bin_size must be <= min(height, width)"
+            )
         data = data[:, :h_crop, :w_crop]
 
         func = np.mean if self.method == "mean" else np.median
@@ -164,9 +169,10 @@ class SpatialBinner:
         # Chi-squared map
         unbinned_chi2 = self.unbin_map(results.chi_squared_map, original_shape)
 
-        # Success mask (boolean)
+        # Success mask (boolean) — NaN-padded edges must become False, not
+        # True (bool(np.nan) is truthy), so replace NaN with 0 before casting.
         unbinned_success_float = self.unbin_map(results.success_mask.astype(np.float64), original_shape)
-        unbinned_success = unbinned_success_float.astype(bool)
+        unbinned_success = np.nan_to_num(unbinned_success_float, nan=0.0).astype(bool)
 
         # Fitted energy maps (optional)
         unbinned_energy_maps = None

--- a/tests/unit/pleiades/imaging/test_binner.py
+++ b/tests/unit/pleiades/imaging/test_binner.py
@@ -1,0 +1,523 @@
+"""Unit tests for pleiades.imaging.binner.SpatialBinner.
+
+Tests cover:
+  - bin_hyperspectral: correct output shape, values, uncertainty propagation
+  - unbin_map: correct upscaling, NaN preservation, shape matching
+  - unbin_results: full round-trip, source_hyperspectral restored, bin_size in metadata
+  - analyze_imaging integration: bin_size=1 regression, bin_size=2 produces original shape
+  - Error handling: invalid bin_size, invalid method, non-2D map
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from pleiades.imaging.binner import SpatialBinner
+from pleiades.imaging.models import HyperspectralData, Imaging2DResults, PixelFitResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_hyperspectral(data: np.ndarray, uncertainty: np.ndarray | None = None) -> HyperspectralData:
+    n_e = data.shape[0]
+    energy = np.linspace(1.0, 100.0, n_e)
+    return HyperspectralData(
+        data=data,
+        energy=energy,
+        uncertainty=uncertainty,
+        source_file=Path("/tmp/test.tif"),
+    )
+
+
+def _make_results(
+    h: int,
+    w: int,
+    n_isotopes: int = 1,
+    hyperspectral: HyperspectralData | None = None,
+) -> Imaging2DResults:
+    """Create a minimal Imaging2DResults for a given spatial size."""
+    if hyperspectral is None:
+        hyperspectral = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, h, w)))
+    abundance = np.random.uniform(0.0, 1.0, (n_isotopes, h, w))
+    chi2 = np.random.uniform(1.0, 5.0, (h, w))
+    success = np.ones((h, w), dtype=bool)
+    return Imaging2DResults(
+        abundance_maps=abundance,
+        isotope_names=[f"iso-{i}" for i in range(n_isotopes)],
+        chi_squared_map=chi2,
+        success_mask=success,
+        source_hyperspectral=hyperspectral,
+        pixel_results=[],
+        metadata={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestSpatialBinnerInit
+# ---------------------------------------------------------------------------
+
+
+class TestSpatialBinnerInit:
+    def test_valid_bin_size(self):
+        b = SpatialBinner(bin_size=2)
+        assert b.bin_size == 2
+        assert b.method == "mean"
+
+    def test_bin_size_1_valid(self):
+        b = SpatialBinner(bin_size=1)
+        assert b.bin_size == 1
+
+    def test_median_method(self):
+        b = SpatialBinner(bin_size=2, method="median")
+        assert b.method == "median"
+
+    def test_invalid_bin_size_zero(self):
+        with pytest.raises(ValueError, match="bin_size"):
+            SpatialBinner(bin_size=0)
+
+    def test_invalid_bin_size_negative(self):
+        with pytest.raises(ValueError, match="bin_size"):
+            SpatialBinner(bin_size=-1)
+
+    def test_invalid_method(self):
+        with pytest.raises(ValueError, match="method"):
+            SpatialBinner(bin_size=2, method="sum")
+
+
+# ---------------------------------------------------------------------------
+# TestBinHyperspectral
+# ---------------------------------------------------------------------------
+
+
+class TestBinHyperspectral:
+    def test_output_shape_bin2(self):
+        data = np.random.uniform(0.5, 0.9, (20, 8, 8))
+        hs = _make_hyperspectral(data)
+        binner = SpatialBinner(bin_size=2)
+        binned = binner.bin_hyperspectral(hs)
+        assert binned.shape == (20, 4, 4)
+
+    def test_output_shape_bin4(self):
+        data = np.random.uniform(0.5, 0.9, (10, 16, 16))
+        hs = _make_hyperspectral(data)
+        binner = SpatialBinner(bin_size=4)
+        binned = binner.bin_hyperspectral(hs)
+        assert binned.shape == (10, 4, 4)
+
+    def test_bin1_is_identity(self):
+        data = np.random.uniform(0.5, 0.9, (10, 8, 8))
+        hs = _make_hyperspectral(data)
+        binner = SpatialBinner(bin_size=1)
+        binned = binner.bin_hyperspectral(hs)
+        assert binned is hs  # Identity returns the same object
+
+    def test_binned_values_are_mean_of_block(self):
+        """A uniform 4×4 block of value v should bin to v."""
+        data = np.full((5, 4, 4), 0.7)
+        hs = _make_hyperspectral(data)
+        binner = SpatialBinner(bin_size=2)
+        binned = binner.bin_hyperspectral(hs)
+        np.testing.assert_allclose(binned.data, 0.7)
+
+    def test_binned_values_mean_of_known_block(self):
+        """Manual 2×2 block mean check."""
+        # (5, 4, 4) array where top-left 2×2 block has a known mean
+        data = np.zeros((1, 4, 4))
+        data[0, :2, :2] = np.array([[1.0, 3.0], [5.0, 7.0]])  # mean = 4.0
+        hs = _make_hyperspectral(data)
+        binner = SpatialBinner(bin_size=2)
+        binned = binner.bin_hyperspectral(hs)
+        assert binned.data[0, 0, 0] == pytest.approx(4.0)
+
+    def test_energy_axis_unchanged(self):
+        data = np.random.uniform(0.5, 0.9, (15, 8, 8))
+        hs = _make_hyperspectral(data)
+        binner = SpatialBinner(bin_size=2)
+        binned = binner.bin_hyperspectral(hs)
+        np.testing.assert_array_equal(binned.energy, hs.energy)
+
+    def test_uncertainty_propagation(self):
+        """σ_bin = σ_pixel / bin_size for uncorrelated Gaussian noise."""
+        sigma_pixel = 0.04
+        data = np.full((5, 8, 8), 0.7)
+        uncertainty = np.full((5, 8, 8), sigma_pixel)
+        hs = _make_hyperspectral(data, uncertainty=uncertainty)
+        binner = SpatialBinner(bin_size=2)
+        binned = binner.bin_hyperspectral(hs)
+
+        expected_sigma = sigma_pixel / 2.0  # σ_bin = σ_pixel / N
+        np.testing.assert_allclose(binned.uncertainty, expected_sigma, rtol=1e-6)
+
+    def test_uncertainty_propagation_bin4(self):
+        sigma_pixel = 0.08
+        data = np.full((5, 8, 8), 0.7)
+        uncertainty = np.full((5, 8, 8), sigma_pixel)
+        hs = _make_hyperspectral(data, uncertainty=uncertainty)
+        binner = SpatialBinner(bin_size=4)
+        binned = binner.bin_hyperspectral(hs)
+
+        expected_sigma = sigma_pixel / 4.0
+        np.testing.assert_allclose(binned.uncertainty, expected_sigma, rtol=1e-6)
+
+    def test_uncertainty_none_stays_none(self):
+        data = np.random.uniform(0.5, 0.9, (5, 8, 8))
+        hs = _make_hyperspectral(data, uncertainty=None)
+        binner = SpatialBinner(bin_size=2)
+        binned = binner.bin_hyperspectral(hs)
+        assert binned.uncertainty is None
+
+    def test_bin_size_in_metadata(self):
+        data = np.random.uniform(0.5, 0.9, (5, 8, 8))
+        hs = _make_hyperspectral(data)
+        binner = SpatialBinner(bin_size=2)
+        binned = binner.bin_hyperspectral(hs)
+        assert binned.metadata["bin_size"] == 2
+
+    def test_source_file_preserved(self):
+        data = np.random.uniform(0.5, 0.9, (5, 8, 8))
+        hs = _make_hyperspectral(data)
+        binner = SpatialBinner(bin_size=2)
+        binned = binner.bin_hyperspectral(hs)
+        assert binned.source_file == hs.source_file
+
+    def test_median_method_different_from_mean(self):
+        data = np.random.uniform(0.2, 0.9, (5, 8, 8))
+        hs = _make_hyperspectral(data)
+        b_mean = SpatialBinner(bin_size=2, method="mean")
+        b_med = SpatialBinner(bin_size=2, method="median")
+        m = b_mean.bin_hyperspectral(hs)
+        med = b_med.bin_hyperspectral(hs)
+        # For non-symmetric blocks, mean ≠ median in general
+        assert not np.allclose(m.data, med.data)
+
+
+# ---------------------------------------------------------------------------
+# TestUnbinMap
+# ---------------------------------------------------------------------------
+
+
+class TestUnbinMap:
+    def test_output_shape_bin2(self):
+        binned = np.ones((4, 4))
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_map(binned, (8, 8))
+        assert unbinned.shape == (8, 8)
+
+    def test_output_shape_bin4(self):
+        binned = np.ones((3, 3))
+        binner = SpatialBinner(bin_size=4)
+        unbinned = binner.unbin_map(binned, (12, 12))
+        assert unbinned.shape == (12, 12)
+
+    def test_values_are_repeated(self):
+        """Each binned value must appear in a bin_size × bin_size tile."""
+        binned = np.array([[1.0, 2.0], [3.0, 4.0]])
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_map(binned, (4, 4))
+        expected = np.array(
+            [
+                [1.0, 1.0, 2.0, 2.0],
+                [1.0, 1.0, 2.0, 2.0],
+                [3.0, 3.0, 4.0, 4.0],
+                [3.0, 3.0, 4.0, 4.0],
+            ]
+        )
+        np.testing.assert_array_equal(unbinned, expected)
+
+    def test_nan_values_preserved(self):
+        binned = np.array([[1.0, np.nan], [np.nan, 2.0]])
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_map(binned, (4, 4))
+        # NaN tiles should remain NaN
+        assert np.all(np.isnan(unbinned[:2, 2:4]))
+        assert np.all(np.isnan(unbinned[2:4, :2]))
+
+    def test_bin1_identity(self):
+        binned = np.array([[1.0, 2.0], [3.0, 4.0]])
+        binner = SpatialBinner(bin_size=1)
+        unbinned = binner.unbin_map(binned, (2, 2))
+        np.testing.assert_array_equal(unbinned, binned)
+
+    def test_non_2d_raises(self):
+        binner = SpatialBinner(bin_size=2)
+        with pytest.raises(ValueError, match="2-D"):
+            binner.unbin_map(np.ones((2, 2, 2)), (4, 4))
+
+    def test_crop_to_original_shape(self):
+        """Upscaling 3-bin map × 2 gives 6, but original was 5 — must crop."""
+        binned = np.ones((3, 3))
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_map(binned, (5, 5))
+        assert unbinned.shape == (5, 5)
+
+
+# ---------------------------------------------------------------------------
+# TestUnbinResults
+# ---------------------------------------------------------------------------
+
+
+class TestUnbinResults:
+    def test_output_shape_abundance_maps(self):
+        orig_h, orig_w = 8, 8
+        orig_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, orig_h, orig_w)))
+        bin_h, bin_w = 4, 4
+        bin_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, bin_h, bin_w)))
+        results = _make_results(bin_h, bin_w, n_isotopes=2, hyperspectral=bin_hs)
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_results(results, orig_hs)
+        assert unbinned.abundance_maps.shape == (2, orig_h, orig_w)
+
+    def test_output_shape_chi2_map(self):
+        orig_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 8, 8)))
+        bin_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 4, 4)))
+        results = _make_results(4, 4, hyperspectral=bin_hs)
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_results(results, orig_hs)
+        assert unbinned.chi_squared_map.shape == (8, 8)
+
+    def test_output_shape_success_mask(self):
+        orig_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 8, 8)))
+        bin_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 4, 4)))
+        results = _make_results(4, 4, hyperspectral=bin_hs)
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_results(results, orig_hs)
+        assert unbinned.success_mask.shape == (8, 8)
+
+    def test_source_hyperspectral_is_original(self):
+        orig_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 8, 8)))
+        bin_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 4, 4)))
+        results = _make_results(4, 4, hyperspectral=bin_hs)
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_results(results, orig_hs)
+        assert unbinned.source_hyperspectral is orig_hs
+
+    def test_bin_size_in_metadata(self):
+        orig_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 8, 8)))
+        bin_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 4, 4)))
+        results = _make_results(4, 4, hyperspectral=bin_hs)
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_results(results, orig_hs)
+        assert unbinned.metadata["bin_size"] == 2
+
+    def test_fitted_energy_maps_unbinned(self):
+        orig_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 8, 8)))
+        bin_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 4, 4)))
+        results = _make_results(4, 4, hyperspectral=bin_hs)
+        # Add fitted_energy_maps
+        results = Imaging2DResults(
+            abundance_maps=results.abundance_maps,
+            isotope_names=results.isotope_names,
+            fitted_energy_maps=np.random.uniform(1.0, 100.0, (2, 4, 4)),
+            chi_squared_map=results.chi_squared_map,
+            success_mask=results.success_mask,
+            source_hyperspectral=bin_hs,
+            pixel_results=[],
+            metadata={},
+        )
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_results(results, orig_hs)
+        assert unbinned.fitted_energy_maps is not None
+        assert unbinned.fitted_energy_maps.shape == (2, 8, 8)
+
+    def test_no_fitted_energy_maps_stays_none(self):
+        orig_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 8, 8)))
+        bin_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 4, 4)))
+        results = _make_results(4, 4, hyperspectral=bin_hs)
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_results(results, orig_hs)
+        assert unbinned.fitted_energy_maps is None
+
+    def test_isotope_names_preserved(self):
+        orig_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 8, 8)))
+        bin_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 4, 4)))
+        results = _make_results(4, 4, n_isotopes=2, hyperspectral=bin_hs)
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_results(results, orig_hs)
+        assert unbinned.isotope_names == results.isotope_names
+
+    def test_pixel_results_preserved(self):
+        orig_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 8, 8)))
+        bin_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 4, 4)))
+        pr = [PixelFitResult(row=0, col=0, fit_results=None, success=False, error_message="x")]
+        results = _make_results(4, 4, hyperspectral=bin_hs)
+        results = Imaging2DResults(
+            abundance_maps=results.abundance_maps,
+            isotope_names=results.isotope_names,
+            chi_squared_map=results.chi_squared_map,
+            success_mask=results.success_mask,
+            source_hyperspectral=bin_hs,
+            pixel_results=pr,
+            metadata={},
+        )
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_results(results, orig_hs)
+        assert unbinned.pixel_results == pr
+
+
+# ---------------------------------------------------------------------------
+# TestAnalyzeImagingBinSize
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeImagingBinSize:
+    """Verify bin_size integration in analyze_imaging."""
+
+    @patch("pleiades.imaging.api.SpatialBinner")
+    @patch("pleiades.imaging.api.ResultsAggregator")
+    @patch("pleiades.imaging.api.BatchFittingOrchestrator")
+    @patch("pleiades.imaging.api.HyperspectralLoader")
+    def test_bin_size_1_does_not_create_binner(
+        self,
+        MockLoader,
+        MockOrchestrator,
+        MockAggregator,
+        MockBinner,
+        tmp_path,
+    ):
+        """bin_size=1 should not instantiate SpatialBinner."""
+        from pleiades.imaging.api import analyze_imaging
+        from pleiades.imaging.config import ImagingConfig
+
+        config = ImagingConfig(
+            isotopes=["Ta-181"],
+            element="Ta",
+            mass_number=181,
+            density_g_cm3=16.6,
+            thickness_mm=0.025,
+            atomic_mass_amu=180.9479958,
+            natural_abundances=True,
+            min_energy_eV=1.0,
+            max_energy_eV=100.0,
+        )
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        data = np.random.uniform(0.5, 0.9, (10, 4, 6))
+        energy = np.linspace(1.0, 100.0, 10)
+        hs = HyperspectralData(data=data, energy=energy, source_file=tmp_path / "d.tif")
+
+        loader_inst = MockLoader.return_value
+        loader_inst.load.return_value = hs
+        loader_inst.iter_pixels.return_value = iter([])
+
+        orch_inst = MockOrchestrator.return_value
+        orch_inst.fit_pixels.return_value = []
+
+        mock_results = MagicMock(spec=Imaging2DResults)
+        agg_inst = MockAggregator.return_value
+        agg_inst.aggregate.return_value = mock_results
+
+        src = tmp_path / "data.tif"
+        src.touch()
+        analyze_imaging(source=src, imaging_config=config, sammy_executable=sammy_exe, bin_size=1)
+
+        MockBinner.assert_not_called()
+
+    @patch("pleiades.imaging.api.ResultsAggregator")
+    @patch("pleiades.imaging.api.BatchFittingOrchestrator")
+    @patch("pleiades.imaging.api.HyperspectralLoader")
+    def test_bin_size_2_produces_original_shape(
+        self,
+        MockLoader,
+        MockOrchestrator,
+        MockAggregator,
+        tmp_path,
+    ):
+        """With bin_size=2 on an 8×8 image, the result maps must be 8×8."""
+        from pleiades.imaging.api import analyze_imaging
+        from pleiades.imaging.config import ImagingConfig
+
+        config = ImagingConfig(
+            isotopes=["Ta-181"],
+            element="Ta",
+            mass_number=181,
+            density_g_cm3=16.6,
+            thickness_mm=0.025,
+            atomic_mass_amu=180.9479958,
+            natural_abundances=True,
+            min_energy_eV=1.0,
+            max_energy_eV=100.0,
+        )
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+
+        # Original 8×8 data
+        data = np.random.uniform(0.5, 0.9, (10, 8, 8))
+        energy = np.linspace(1.0, 100.0, 10)
+        orig_hs = HyperspectralData(data=data, energy=energy, source_file=tmp_path / "d.tif")
+
+        loader_inst = MockLoader.return_value
+        loader_inst.load.return_value = orig_hs
+        loader_inst.iter_pixels.return_value = iter([])
+
+        orch_inst = MockOrchestrator.return_value
+        # fit_pixels returns empty list; aggregator will build 4×4 maps for binned data
+        orch_inst.fit_pixels.return_value = []
+
+        # Aggregator will be called with binned hyperspectral (4×4)
+        # We configure it to return a 4×4 result
+        bin_hs = HyperspectralData(
+            data=np.random.uniform(0.5, 0.9, (10, 4, 4)),
+            energy=energy,
+            source_file=tmp_path / "d.tif",
+        )
+        binned_result = Imaging2DResults(
+            abundance_maps=np.full((1, 4, 4), 0.5),
+            isotope_names=["Ta-181"],
+            chi_squared_map=np.ones((4, 4)),
+            success_mask=np.ones((4, 4), dtype=bool),
+            source_hyperspectral=bin_hs,
+            pixel_results=[],
+            metadata={},
+        )
+        agg_inst = MockAggregator.return_value
+        agg_inst.aggregate.return_value = binned_result
+
+        src = tmp_path / "data.tif"
+        src.touch()
+        result = analyze_imaging(source=src, imaging_config=config, sammy_executable=sammy_exe, bin_size=2)
+
+        # After unbinning, maps should be at original 8×8 resolution
+        assert result.abundance_maps.shape == (1, 8, 8)
+        assert result.chi_squared_map.shape == (8, 8)
+        assert result.success_mask.shape == (8, 8)
+        assert result.source_hyperspectral is orig_hs
+
+    @patch("pleiades.imaging.api.ResultsAggregator")
+    @patch("pleiades.imaging.api.BatchFittingOrchestrator")
+    @patch("pleiades.imaging.api.HyperspectralLoader")
+    def test_bin_size_zero_raises(
+        self,
+        MockLoader,
+        MockOrchestrator,
+        MockAggregator,
+        tmp_path,
+    ):
+        """bin_size=0 must raise ValueError before any IO."""
+        from pleiades.imaging.api import analyze_imaging
+        from pleiades.imaging.config import ImagingConfig
+
+        config = ImagingConfig(
+            isotopes=["Ta-181"],
+            element="Ta",
+            mass_number=181,
+            density_g_cm3=16.6,
+            thickness_mm=0.025,
+            atomic_mass_amu=180.9479958,
+            natural_abundances=True,
+            min_energy_eV=1.0,
+            max_energy_eV=100.0,
+        )
+        sammy_exe = tmp_path / "sammy"
+        sammy_exe.touch()
+        src = tmp_path / "data.tif"
+        src.touch()
+
+        with pytest.raises(ValueError, match="bin_size"):
+            analyze_imaging(source=src, imaging_config=config, sammy_executable=sammy_exe, bin_size=0)

--- a/tests/unit/pleiades/imaging/test_binner.py
+++ b/tests/unit/pleiades/imaging/test_binner.py
@@ -206,6 +206,14 @@ class TestBinHyperspectral:
         expected = np.sqrt(0.1**2 + 0.2**2 + 0.3**2 + 0.4**2) / 4
         np.testing.assert_allclose(binned.uncertainty[0, 0, 0], expected, rtol=1e-10)
 
+    def test_bin_size_larger_than_image_raises(self):
+        """bin_size > min(height, width) should raise ValueError."""
+        data = np.ones((5, 3, 3))
+        hs = _make_hyperspectral(data)
+        binner = SpatialBinner(bin_size=4)
+        with pytest.raises(ValueError, match="zero-sized"):
+            binner.bin_hyperspectral(hs)
+
     def test_median_method_different_from_mean(self):
         data = np.random.uniform(0.2, 0.9, (5, 8, 8))
         hs = _make_hyperspectral(data)
@@ -378,6 +386,30 @@ class TestUnbinResults:
         binner = SpatialBinner(bin_size=2)
         unbinned = binner.unbin_results(results, orig_hs)
         assert unbinned.pixel_results == pr
+
+    def test_success_mask_nan_padded_edges_are_false(self):
+        """NaN-padded edge pixels in success_mask must be False, not True."""
+        # Original 5×5, binned 2×2 → 2×2 binned result, unbin to 5×5
+        orig_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 5, 5)))
+        bin_hs = _make_hyperspectral(np.random.uniform(0.5, 0.9, (10, 2, 2)))
+        results = Imaging2DResults(
+            abundance_maps=np.full((1, 2, 2), 0.5),
+            isotope_names=["iso-0"],
+            chi_squared_map=np.ones((2, 2)),
+            success_mask=np.ones((2, 2), dtype=bool),
+            source_hyperspectral=bin_hs,
+            pixel_results=[],
+            metadata={},
+        )
+        binner = SpatialBinner(bin_size=2)
+        unbinned = binner.unbin_results(results, orig_hs)
+        # The 5th row and column are NaN-padded; success_mask should be False there
+        assert not unbinned.success_mask[4, 0]
+        assert not unbinned.success_mask[0, 4]
+        assert not unbinned.success_mask[4, 4]
+        # Fitted region should still be True
+        assert unbinned.success_mask[0, 0]
+        assert unbinned.success_mask[3, 3]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/pleiades/imaging/test_binner.py
+++ b/tests/unit/pleiades/imaging/test_binner.py
@@ -186,6 +186,26 @@ class TestBinHyperspectral:
         binned = binner.bin_hyperspectral(hs)
         assert binned.source_file == hs.source_file
 
+    def test_non_divisible_dimensions_cropped(self):
+        """9×9 image with bin_size=2 should produce (4, 4), not (5, 5)."""
+        data = np.ones((5, 9, 9))
+        hs = _make_hyperspectral(data)
+        binner = SpatialBinner(bin_size=2)
+        binned = binner.bin_hyperspectral(hs)
+        assert binned.shape == (5, 4, 4)
+        # All ones → binned values should be exactly 1.0 (no zero-padding bias)
+        np.testing.assert_allclose(binned.data, 1.0)
+
+    def test_uncertainty_propagation_heterogeneous(self):
+        """Verify sqrt(sum(sigma_i^2))/N for non-uniform uncertainties."""
+        data = np.full((1, 2, 2), 0.5)
+        uncertainty = np.array([[[0.1, 0.2], [0.3, 0.4]]]).astype(np.float64)
+        hs = _make_hyperspectral(data, uncertainty=uncertainty)
+        binner = SpatialBinner(bin_size=2)
+        binned = binner.bin_hyperspectral(hs)
+        expected = np.sqrt(0.1**2 + 0.2**2 + 0.3**2 + 0.4**2) / 4
+        np.testing.assert_allclose(binned.uncertainty[0, 0, 0], expected, rtol=1e-10)
+
     def test_median_method_different_from_mean(self):
         data = np.random.uniform(0.2, 0.9, (5, 8, 8))
         hs = _make_hyperspectral(data)


### PR DESCRIPTION
## Summary

- Adds `SpatialBinner` in `src/pleiades/imaging/binner.py`:
  - `bin_hyperspectral`: reduces `(n_e, H, W)` → `(n_e, H//N, W//N)` via `skimage.measure.block_reduce`; uncertainty propagation `σ_bin = σ_pixel / N`
  - `unbin_map`: nearest-neighbour upscale of 2D maps with NaN preservation and shape cropping
  - `unbin_results`: upscales all maps in `Imaging2DResults` back to original resolution; restores `source_hyperspectral`
- Adds `bin_size: int = 1` parameter to `analyze_imaging()` (fully backward-compatible default)
- Exports `SpatialBinner` from `pleiades.imaging`
- 37 new unit tests in `test_binner.py`

## Test plan
- [x] `pixi run pytest tests/unit/pleiades/imaging/test_binner.py -v` → 37 passed
- [x] `pixi run pytest tests/unit/pleiades/imaging/ -v` → 463 passed, 0 regressions
- [ ] `analyze_imaging(..., bin_size=1)` behaves identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)