### PR TITLE
fix(nuclear): correct AME2020 field indices for atomic_number lookup

### DIFF
--- a/src/pleiades/nuclear/isotopes/manager.py
+++ b/src/pleiades/nuclear/isotopes/manager.py
@@ -270,22 +270,19 @@ class IsotopeManager:
                 for _ in range(36):
                     next(f)
                 for line in f:
-                    # AME2020 format: columns N Z A EL ... (whitespace-separated in first 25 chars)
-                    # Use exact field comparison to avoid substring false-matches
-                    # (e.g. mass 41 matching 241, or symbol appearing inside another word).
+                    # AME2020 format (whitespace-separated fields in first ~25 chars):
+                    #   parts[0] = page/index, parts[1] = N, parts[2] = Z,
+                    #   parts[3] = A (mass number), parts[4] = element symbol
                     parts = line[:25].split()
-                    if len(parts) < 4:
+                    if len(parts) < 5:
                         continue
                     try:
-                        a_field = int(parts[2])
+                        a_field = int(parts[3])
                     except ValueError:
                         continue
-                    symbol_field = parts[3]
+                    symbol_field = parts[4]
                     if symbol_field == element and a_field == mass_number:
-                        # Z is in columns 10-12 (1-based), i.e. indices 9:12
-                        z_str = line[9:12].strip()
-                        if z_str:
-                            return int(z_str)
+                        return int(parts[2])
         except Exception as e:
             logger.warning(f"Could not extract atomic number for {element}-{mass_number}: {e}")
         return None


### PR DESCRIPTION
## Summary

Fixes a `TypeError: unsupported format string passed to NoneType.__format__` when running `fit_pixels` for isotopes like Pu-241.

**Root cause**: `_get_atomic_number_from_mass_file` in `isotopes/manager.py` parsed the AME2020 `mass.mas20` file with wrong field indices:

| Field | Was read as | Actual content |
|-------|------------|----------------|
| `parts[2]` | A (mass number) | Z (atomic number) |
| `parts[3]` | element symbol | A (mass number) |
| `line[9:12]` | Z | whitespace |

The 5-field format is `[page_idx, N, Z, A, element]`. The fix uses `parts[3]` for A, `parts[4]` for the element symbol, and `parts[2]` directly for Z.

**Affected isotopes**: Any radioactive isotope absent from `isotopes.info` (e.g. Pu-241, other actinides). Stable isotopes with entries in `isotopes.info` were unaffected because they take the earlier `check_and_set_abundance_and_spins` path.

## Test plan
- [x] `pixi run pytest tests/unit/pleiades/nuclear/ -v` → 36 passed
- [x] `IsotopeManager().get_isotope_info("Pu-241").atomic_number == 94` ✓
- [x] Notebook: `fit_pixels` no longer raises `TypeError` for Pu-241

🤖 Generated with [Claude Code](https://claude.com/claude-code)